### PR TITLE
Align with JSS for XM Cloud Rich Text Editor Styles

### DIFF
--- a/src/Sitecore.AspNetCore.SDK.Pages/Configuration/PagesOptions.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Configuration/PagesOptions.cs
@@ -49,4 +49,20 @@ public class PagesOptions
     /// Gets or sets the number of entries per page in a dictionary. The default value is set to 1000.
     /// </summary>
     public int DictionaryPageSize { get; set; } = 1000;
+
+    /// <summary>
+    /// Gets or sets the URL for the Pages asset server.
+    /// </summary>
+    public string PagesAssetServerUrl { get; set; } = "https://pages.sitecorecloud.io";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to enable the new XM Cloud Rich Text Editor styles.
+    /// This is typically controlled by the PAGES_ENABLE_NEW_RTE_EDITOR environment variable.
+    /// </summary>
+    public bool EnableNewRteEditor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ContextId for the environment being used.
+    /// </summary>
+    public string? ContextId { get; set; }
 }

--- a/src/Sitecore.AspNetCore.SDK.Pages/Constants.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Constants.cs
@@ -82,5 +82,16 @@
             /// </summary>
             public const string EditMode = "sc_editmode";
         }
+
+        /// <summary>
+        /// Class used to hold HttpContext item keys.
+        /// </summary>
+        public static class HttpContextItems
+        {
+            /// <summary>
+            /// Key for the RTE styles.
+            /// </summary>
+            public const string RteStyles = "sc_rte_styles";
+        }
     }
 }

--- a/src/Sitecore.AspNetCore.SDK.Pages/Services/ContentStylesService.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Services/ContentStylesService.cs
@@ -1,0 +1,114 @@
+using Microsoft.Extensions.Options;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
+using Sitecore.AspNetCore.SDK.Pages.Configuration;
+using System.Linq;
+
+namespace Sitecore.AspNetCore.SDK.Pages.Services;
+
+/// <summary>
+/// Service to detect and provide links for content-related stylesheets, such as for the Rich Text Editor.
+/// </summary>
+public class ContentStylesService : IContentStylesService
+{
+    private const string CkContentClassName = "ck-content";
+    private readonly PagesOptions _pagesOptions;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ContentStylesService"/> class.
+    /// </summary>
+    /// <param name="pagesOptions">The pages configuration options.</param>
+    public ContentStylesService(IOptions<PagesOptions> pagesOptions)
+    {
+        ArgumentNullException.ThrowIfNull(pagesOptions);
+        _pagesOptions = pagesOptions.Value;
+    }
+
+    /// <inheritdoc />
+    public virtual string? GetContentStylesheetLink(SitecoreLayoutResponseContent? layoutData)
+    {
+        if (!_pagesOptions.EnableNewRteEditor || layoutData?.Sitecore?.Route == null)
+        {
+            return null;
+        }
+
+        bool stylesRequired = false;
+        if (layoutData.Sitecore.Route.Placeholders != null)
+        {
+            foreach (var placeholder in layoutData.Sitecore.Route.Placeholders.Values)
+            {
+                foreach (var component in placeholder.Where(c => c is Component).Cast<Component>())
+                {
+                    if (HasCkContentClass(component))
+                    {
+                        stylesRequired = true;
+                        break;
+                    }
+                }
+
+                if (stylesRequired)
+                {
+                    break;
+                }
+            }
+        }
+
+        return stylesRequired ? $"{_pagesOptions.PagesAssetServerUrl}/pages/styles/content-styles.min.css" : null;
+    }
+
+    private static bool HasCkContentClass(Component? component)
+    {
+        if (component == null)
+        {
+            return false;
+        }
+
+        if (component.Fields != null)
+        {
+            foreach (IFieldReader field in component.Fields.Values)
+            {
+                if (IsRichTextWithCkContent(field))
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (component.Placeholders != null)
+        {
+            foreach (Placeholder placeholder in component.Placeholders.Values)
+            {
+                foreach (Component childComponent in placeholder.Where(c => c is Component).Cast<Component>())
+                {
+                    if (HasCkContentClass(childComponent))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsRichTextWithCkContent(IFieldReader fieldReader)
+    {
+        if (fieldReader is not RichTextField richTextField)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(richTextField.EditableMarkup) && richTextField.EditableMarkup.Contains(CkContentClassName, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrEmpty(richTextField.Value) && richTextField.Value.Contains(CkContentClassName, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/Services/IContentStylesService.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Services/IContentStylesService.cs
@@ -1,0 +1,16 @@
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;
+
+namespace Sitecore.AspNetCore.SDK.Pages.Services;
+
+/// <summary>
+/// Defines the contract for a service that detects and provides links for content-related stylesheets.
+/// </summary>
+public interface IContentStylesService
+{
+    /// <summary>
+    /// Traverses the layout data and returns a stylesheet URL if content styles (e.g., for the new RTE) are required.
+    /// </summary>
+    /// <param name="layoutData">The layout service response content to traverse.</param>
+    /// <returns>A URL to a stylesheet, or null if no specific styles are required.</returns>
+    string? GetContentStylesheetLink(SitecoreLayoutResponseContent? layoutData);
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Apply the label "bug" or "enhancement" as applicable. -->

## Description / Motivation
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Support for the new XM Cloud Rich Text Editor (RTE) stylesheet feature, aligning the .NET SDK's behavior with the JSS v21.5.2 implementation. The primary goal is to automatically inject the necessary `content-styles.min.css` stylesheet when RTE content requiring it is present in the layout data, but only for Sitecore Pages (XM Cloud).



## Testing

- [x] The Unit & Intergration tests are passing.
- [ ] I have added the necessary tests to cover my changes.

## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [ ] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md).
