### PR TITLE
Enable SrcSet support with three different input formats and test cas…

### DIFF
--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -45,7 +45,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 {
                     return $"{kvp.Value}w";
                 }
-                
+
                 if (kvp.Key.Equals("w", StringComparison.OrdinalIgnoreCase) ||
                     kvp.Key.Equals("width", StringComparison.OrdinalIgnoreCase))
                 {
@@ -57,7 +57,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             // Handle anonymous objects via reflection
             var properties = parameters.GetType().GetProperties();
-            
+
             foreach (var prop in properties)
             {
                 if (prop.Name.Equals("mw", StringComparison.OrdinalIgnoreCase) ||
@@ -65,7 +65,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 {
                     return $"{prop.GetValue(parameters)}w";
                 }
-                
+
                 if (prop.Name.Equals("w", StringComparison.OrdinalIgnoreCase) ||
                     prop.Name.Equals("width", StringComparison.OrdinalIgnoreCase))
                 {
@@ -84,13 +84,13 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             return null;
         }
-        
+
         // If already an object array, use as-is
         if (srcSetValue is object[] objectArray)
         {
             return objectArray;
         }
-        
+
         // If it's a JSON string, parse it
         if (srcSetValue is string jsonString)
         {
@@ -105,7 +105,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 return null;
             }
         }
-        
+
         // Single object - wrap in array
         return new[] { srcSetValue };
     }
@@ -260,7 +260,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         if (!string.IsNullOrWhiteSpace(image.Src))
         {
             tagBuilder.Attributes.Add(ScrAttribute, imageField.GetMediaLink(ImageParams));
-            
+
             // Add srcset if configured
             if (SrcSet != null)
             {
@@ -354,7 +354,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
             }
 
             imageNode.SetAttributeValue(ScrAttribute, imageField.GetMediaLink(ImageParams));
-            
+
             // Add srcset for editable content
             if (SrcSet != null)
             {

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
@@ -798,7 +798,7 @@ public class ImageTagHelperFixture
         {
             EditableMarkup = "<img src=\"/sitecore/shell/-/jssmedia/img/sc_logo.png\" alt=\"Sitecore Logo\" />"
         };
-        
+
         tagHelperOutput.TagName = RenderingEngineConstants.SitecoreTagHelpers.ImageHtmlTag;
         sut.For = GetModelExpression(imageField);
         sut.SrcSet = new object[] { new { mw = 600 }, new { mw = 300 } };


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Apply the label "bug" or "enhancement" as applicable. -->

## Description / Motivation
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This PR implements responsive image support for the `ImageTagHelper` by adding `srcset` and `sizes` attribute functionality, enabling developers to output responsive images using Sitecore's built-in media resizing capabilities to better support mobile devices.

### Key Changes:

1. **Added `SrcSet` and `Sizes` Properties**: Extended the `ImageTagHelper` with new properties to support responsive image configuration for the `<sc-img>` tag.

2. **Multiple Input Format Support**: The `SrcSet` property accepts three different input formats for maximum flexibility:
   - **Anonymous objects**: `new object[] { new { mw = 300 }, new { mw = 100 } }`
   - **Dictionary arrays**: `new Dictionary<string, object> { {"mw", 300} }`
   - **JSON strings**: `[{"mw": 300}, {"mw": 100}]` (most JSS-like syntax)

3. **Comprehensive Parameter Support**: Recognizes common Sitecore media parameters:
   - `mw` (max width)
   - `w` (width)
   - `maxWidth` (camelCase)
   - `width` (full word)

4. **Enhanced HTML Output**: Generates proper HTML5 responsive image markup:
   ```html
   <img src="/media/image.jpg" 
        srcset="/media/image.jpg?mw=300 300w, /media/image.jpg?mw=100 100w"
        sizes="(min-width: 960px) 300px, 100px"
        alt="..." />
   ```

5. **Editable Content Support**: Works seamlessly with both normal rendering and Experience Editor editable markup.

6. **Backward Compatibility**: All existing functionality remains unchanged; new features are opt-in.

### Usage Examples:

```html
<!-- Using anonymous objects -->
<sc-img asp-for="Model.MyImageField" 
        src-set='new object[] { new { mw = 300 }, new { mw = 100 } }'
        sizes="(min-width: 960px) 300px, 100px" />

<!-- Using JSON strings (JSS-like) -->
<sc-img asp-for="Model.MyImageField" 
        src-set='[{"mw": 400}, {"mw": 200}]'
        sizes="(min-width: 768px) 400px, 200px" />

<!-- Using dictionary arrays -->
<sc-img asp-for="Model.MyImageField" 
        src-set='new object[] { 
            new Dictionary<string, object> { { "mw", 300 } }, 
            new Dictionary<string, object> { { "mw", 100 } } 
        }' />
```

This implementation aligns with modern web standards for responsive images and provides the same level of functionality found in JSS, enabling better mobile device support through automatic image optimization using Sitecore's powerful media resizing capabilities.

## Testing

- [x] The Unit & Integration tests are passing.
- [x] I have added the necessary tests to cover my changes.
- [x] Added comprehensive test coverage for all three input formats
- [x] Added tests for mixed parameter types and error handling scenarios
- [x] Added tests for `<sc-img>` tag scenarios with srcset content generation
- [x] Added tests for editable markup integration with srcset attributes
- [x] Added tests for graceful fallback when invalid JSON is provided

## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [x] I agree to follow this project's Code of Conduct.