### PR TITLE
Enable SrcSet support with three different input formats for Image tag helper

### DIFF
--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -41,27 +41,27 @@ public static partial class SitecoreFieldExtensions
         {
             // Parse existing query parameters from the original URL
             var originalParams = ParseUrlParameters(url);
-            
+
             // Split URL to get base path
             string[] urlParts = url.Split('?');
             string baseUrl = urlParts[0];
-            
+
             // Merge original parameters with new ones (new ones take precedence)
             RouteValueDictionary newParameters = new(imageParams);
-            
+
             // Start with original parameters
             RouteValueDictionary mergedParams = new();
             foreach (var kvp in originalParams)
             {
                 mergedParams[kvp.Key] = kvp.Value;
             }
-            
+
             // Add/override with new parameters
             foreach (string key in newParameters.Keys)
             {
                 mergedParams[key] = newParameters[key];
             }
-            
+
             // Rebuild URL with merged parameters
             url = baseUrl;
             foreach (string key in mergedParams.Keys)
@@ -91,21 +91,21 @@ public static partial class SitecoreFieldExtensions
     private static Dictionary<string, object> ParseUrlParameters(string url)
     {
         var parameters = new Dictionary<string, object>();
-        
+
         if (string.IsNullOrEmpty(url))
         {
             return parameters;
         }
-        
+
         var queryIndex = url.IndexOf('?');
         if (queryIndex == -1)
         {
             return parameters;
         }
-        
+
         var queryString = url.Substring(queryIndex + 1);
         var parsedQuery = QueryHelpers.ParseQuery(queryString);
-        
+
         foreach (var kvp in parsedQuery)
         {
             if (kvp.Value.Count > 0)
@@ -113,7 +113,7 @@ public static partial class SitecoreFieldExtensions
                 parameters[kvp.Key] = kvp.Value.First() ?? string.Empty;
             }
         }
-        
+
         return parameters;
     }
 

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -37,7 +37,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
     private static string GetWidthDescriptor(object parameters)
     {
         string? width = null;
-        
+
         // Handle Dictionary<string, object>
         if (parameters is Dictionary<string, object> dictionary)
         {
@@ -63,7 +63,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             // Handle anonymous objects via reflection
             var type = parameters.GetType();
-            
+
             // Priority: w > mw > width > maxWidth (matching Content SDK behavior and supporting legacy parameters)
             var wProperty = type.GetProperty("w");
             if (wProperty != null)
@@ -102,7 +102,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
     private static object MergeParameters(object? imageParams, object srcSetParams)
     {
         var mergedDict = new Dictionary<string, object?>();
-        
+
         // Add base imageParams first
         if (imageParams != null)
         {
@@ -115,7 +115,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 }
             }
         }
-        
+
         // Add srcSet parameters (these take precedence)
         var srcParams = new RouteValueDictionary(srcSetParams);
         foreach (var kvp in srcParams)
@@ -439,10 +439,10 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             // Merge ImageParams with srcSet parameters (Content SDK behavior)
             var mergedParams = MergeParameters(ImageParams, srcSetItem);
-            
+
             // Get the width descriptor from the original srcSet item (not merged params)
             string descriptor = GetWidthDescriptor(srcSetItem);
-            
+
             // Only include entries that have a valid width descriptor
             if (!string.IsNullOrEmpty(descriptor))
             {

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
@@ -779,7 +779,7 @@ public class ImageTagHelperFixture
         content.Should().Contain("1000w"); // From 'w' parameter (priority over mw)
         content.Should().Contain("250w");  // From 'mw' parameter
         content.Should().Contain("quality=80"); // Base imageParams should be merged
-        
+
         // Verify Content SDK behavior: w parameter takes precedence over mw
         content.Should().Contain("w=1000"); // First entry should use 'w' parameter
         content.Should().Contain("mw=250"); // Second entry should use 'mw' parameter
@@ -935,19 +935,19 @@ public class ImageTagHelperFixture
         // Assert
         string content = tagHelperOutput.Content.GetContent();
         content.Should().Contain("srcset=");
-        
+
         // Verify that original cache-busting parameters are preserved in srcset URLs
         content.Should().Contain("ttc=63888067993", "cache timestamp should be preserved");
         content.Should().Contain("tt=79223DA7F3AE658CE8F43731B252D6BC", "cache token should be preserved");
         content.Should().Contain("hash=6CD37A62DE0B8CB9DC4EE19936C2D41E", "hash should be preserved");
         content.Should().Contain("iar=0", "ignore aspect ratio should be preserved");
-        
+
         // Verify that new parameters are added
         content.Should().Contain("w=800", "new width parameter should be added");
         content.Should().Contain("h=400", "new height parameter should be added");
         content.Should().Contain("mw=400", "new max width parameter should be added");
         content.Should().Contain("q=75", "image params should be merged");
-        
+
         // Verify srcset descriptors are correct
         content.Should().Contain("800w", "first srcset entry should have width descriptor");
         content.Should().Contain("400w", "second srcset entry should have width descriptor");


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Apply the label "bug" or "enhancement" as applicable. -->

## Description / Motivation
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This PR implements responsive image support for the `ImageTagHelper` by adding `srcset` and `sizes` attribute functionality, enabling developers to output responsive images using Sitecore's built-in media resizing capabilities. The implementation matches the Content SDK (JSS replacement) behavior to ensure consistent output across .NET and JavaScript frameworks.

### Key Changes:

1. **Added `SrcSet` and `Sizes` Properties**: Extended the `ImageTagHelper` with new properties to support responsive image configuration for both `<sc-img>` and `<img>` tags.

2. **Multiple Input Format Support**: The `SrcSet` property accepts three different input formats for maximum flexibility:
   - **Anonymous objects**: `new object[] { new { w = 800 }, new { mw = 400 } }`
   - **Dictionary arrays**: `new Dictionary<string, object> { {"w", 800} }`
   - **JSON strings**: `[{"w": 800}, {"mw": 400}]` (most JSS-like syntax)

3. **Content SDK Parameter Priority**: Implements the same parameter precedence as Content SDK:
   - `w` (width) takes priority over `mw` (max width) for srcset descriptors
   - Only entries with valid `w` or `mw` parameters are included in srcset
   - Matches Content SDK's `getSrcSet` function behavior exactly

4. **Enhanced Parameter Merging**: 
   - Base `imageParams` are merged with individual `srcSet` parameters
   - `srcSet` parameters override `imageParams` for each srcset entry
   - Preserves existing query parameters (rev, db, la, vs, ts, hash, etc.)
   - Follows Content SDK's `{ ...imageParams, ...params }` merge pattern

5. **URL Transformation**: 
   - Transforms `/media/` URLs to `/jssmedia/` (Content SDK compatible)
   - Preserves cache-busting and required parameters
   - Handles both XM Cloud and on-premise URL structures

6. **Enhanced HTML Output**: Generates proper HTML5 responsive image markup:
   ```html
   <img src="/~/jssmedia/image.jpg?quality=80" 
        srcset="/~/jssmedia/image.jpg?quality=80&w=800 800w, /~/jssmedia/image.jpg?quality=80&mw=400 400w"
        sizes="(min-width: 768px) 800px, 400px"
        alt="..." />
   ```

7. **Experience Editor Support**: Works seamlessly with both normal rendering and Experience Editor editable markup.

8. **Backward Compatibility**: All existing functionality remains unchanged; new features are opt-in.

### Content SDK Compatibility:

The implementation now produces identical output to the Content SDK's `Image` component:

**Content SDK (React):**
```jsx
<Image 
  field={imageField} 
  imageParams={{quality: 80}} 
  srcSet={[{w: 800}, {mw: 400}]} 
  sizes="(min-width: 768px) 800px, 400px" 
/>
```

**ASP.NET Core SDK (Razor):**
```html
<sc-img asp-for="@Model.ImageField" 
        image-params='new { quality = 80 }'
        src-set='new object[] { new { w = 800 }, new { mw = 400 } }'
        sizes="(min-width: 768px) 800px, 400px" />
```

**Both produce identical HTML:**
```html
<img src="/~/jssmedia/image.jpg?quality=80" 
     srcset="/~/jssmedia/image.jpg?quality=80&w=800 800w, /~/jssmedia/image.jpg?quality=80&mw=400 400w"
     sizes="(min-width: 768px) 800px, 400px" 
     alt="Image" />
```

### Usage Examples:

```html
<!-- Basic responsive image -->
<sc-img asp-for="@Model.HeroImage" 
        src-set='new object[] { new { w = 1200 }, new { w = 800 }, new { w = 400 } }'
        sizes="(min-width: 1200px) 1200px, (min-width: 800px) 800px, 400px" />

<!-- With base parameters -->
<img asp-for="@Model.ProductImage" 
     image-params='new { quality = 80, format = "webp" }'
     src-set='new object[] { new { w = 800, h = 600 }, new { mw = 400, mh = 300 } }'
     sizes="(min-width: 768px) 800px, 400px" />

<!-- JSON string format -->
@{
    string jsonSrcSet = """[{"w": 1000}, {"mw": 500}]""";
}
<sc-img asp-for="@Model.BannerImage" 
        src-set="@jsonSrcSet"
        sizes="(min-width: 960px) 1000px, 500px" />
```

This implementation ensures feature parity with the Content SDK while maintaining the familiar ASP.NET Core TagHelper syntax and full backward compatibility.

## Testing

- [x] The Unit & Integration tests are passing.
- [x] I have added the necessary tests to cover my changes.
- [x] Added comprehensive test coverage for all three input formats
- [x] Added tests for Content SDK parameter priority (w > mw)
- [x] Added tests for parameter merging with imageParams and srcSet parameters
- [x] Added tests for cache-busting parameter preservation
- [x] Added tests for both `<sc-img>` and `<img>` tag scenarios
- [x] Added tests for Experience Editor editable markup integration
- [x] Added tests for entry filtering (only w/mw parameters included)
- [x] Added tests for graceful fallback when invalid JSON is provided

## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [x] I agree to follow this project's Code of Conduct.

Fix #16
