### PR TITLE
Produce exactly the same HTML as Content SDK

### DIFF
--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -41,27 +41,27 @@ public static partial class SitecoreFieldExtensions
         {
             // Parse existing query parameters from the original URL
             var originalParams = ParseUrlParameters(url);
-            
+
             // Split URL to get base path
             string[] urlParts = url.Split('?');
             string baseUrl = urlParts[0];
-            
+
             // Merge original parameters with new ones (new ones take precedence)
             RouteValueDictionary newParameters = new(imageParams);
-            
+
             // Start with original parameters
             RouteValueDictionary mergedParams = new();
             foreach (var kvp in originalParams)
             {
                 mergedParams[kvp.Key] = kvp.Value;
             }
-            
+
             // Add/override with new parameters
             foreach (string key in newParameters.Keys)
             {
                 mergedParams[key] = newParameters[key];
             }
-            
+
             // Rebuild URL with merged parameters
             url = baseUrl;
             foreach (string key in mergedParams.Keys)
@@ -91,21 +91,21 @@ public static partial class SitecoreFieldExtensions
     private static Dictionary<string, object> ParseUrlParameters(string url)
     {
         var parameters = new Dictionary<string, object>();
-        
+
         if (string.IsNullOrEmpty(url))
         {
             return parameters;
         }
-        
+
         var queryIndex = url.IndexOf('?');
         if (queryIndex == -1)
         {
             return parameters;
         }
-        
+
         var queryString = url.Substring(queryIndex + 1);
         var parsedQuery = QueryHelpers.ParseQuery(queryString);
-        
+
         foreach (var kvp in parsedQuery)
         {
             if (kvp.Value.Count > 0)
@@ -113,7 +113,7 @@ public static partial class SitecoreFieldExtensions
                 parameters[kvp.Key] = kvp.Value.First() ?? string.Empty;
             }
         }
-        
+
         return parameters;
     }
 

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -37,7 +37,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
     private static string GetWidthDescriptor(object parameters)
     {
         string? width = null;
-        
+
         // Handle Dictionary<string, object>
         if (parameters is Dictionary<string, object> dictionary)
         {
@@ -63,7 +63,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             // Handle anonymous objects via reflection
             var type = parameters.GetType();
-            
+
             // Priority: w > mw > width > maxWidth (matching Content SDK behavior and supporting legacy parameters)
             var wProperty = type.GetProperty("w");
             if (wProperty != null)
@@ -102,7 +102,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
     private static object MergeParameters(object? imageParams, object srcSetParams)
     {
         var mergedDict = new Dictionary<string, object?>();
-        
+
         // Add base imageParams first
         if (imageParams != null)
         {
@@ -115,7 +115,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 }
             }
         }
-        
+
         // Add srcSet parameters (these take precedence)
         var srcParams = new RouteValueDictionary(srcSetParams);
         foreach (var kvp in srcParams)
@@ -439,10 +439,10 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             // Merge ImageParams with srcSet parameters (Content SDK behavior)
             var mergedParams = MergeParameters(ImageParams, srcSetItem);
-            
+
             // Get the width descriptor from the original srcSet item (not merged params)
             string descriptor = GetWidthDescriptor(srcSetItem);
-            
+
             // Only include entries that have a valid width descriptor
             if (!string.IsNullOrEmpty(descriptor))
             {

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
@@ -779,7 +779,7 @@ public class ImageTagHelperFixture
         content.Should().Contain("1000w"); // From 'w' parameter (priority over mw)
         content.Should().Contain("250w");  // From 'mw' parameter
         content.Should().Contain("quality=80"); // Base imageParams should be merged
-        
+
         // Verify Content SDK behavior: w parameter takes precedence over mw
         content.Should().Contain("w=1000"); // First entry should use 'w' parameter
         content.Should().Contain("mw=250"); // Second entry should use 'mw' parameter
@@ -935,19 +935,19 @@ public class ImageTagHelperFixture
         // Assert
         string content = tagHelperOutput.Content.GetContent();
         content.Should().Contain("srcset=");
-        
+
         // Verify that original cache-busting parameters are preserved in srcset URLs
         content.Should().Contain("ttc=63888067993", "cache timestamp should be preserved");
         content.Should().Contain("tt=79223DA7F3AE658CE8F43731B252D6BC", "cache token should be preserved");
         content.Should().Contain("hash=6CD37A62DE0B8CB9DC4EE19936C2D41E", "hash should be preserved");
         content.Should().Contain("iar=0", "ignore aspect ratio should be preserved");
-        
+
         // Verify that new parameters are added
         content.Should().Contain("w=800", "new width parameter should be added");
         content.Should().Contain("h=400", "new height parameter should be added");
         content.Should().Contain("mw=400", "new max width parameter should be added");
         content.Should().Contain("q=75", "image params should be merged");
-        
+
         // Verify srcset descriptors are correct
         content.Should().Contain("800w", "first srcset entry should have width descriptor");
         content.Should().Contain("400w", "second srcset entry should have width descriptor");


### PR DESCRIPTION
Parameter merging with srcSet precedence
Width descriptor priority (w > mw)
URL transformation to /jssmedia/
Parameter preservation for cache-busting
Fallback src always provided