### PR TITLE
Updated - Enable SrcSet support with three different input formats for Image tag helper

### DIFF
--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -30,6 +30,80 @@ public static partial class SitecoreFieldExtensions
     }
 
     /// <summary>
+    /// Gets modified URL string to Sitecore media item with merged parameters.
+    /// </summary>
+    /// <param name="imageField">The image field.</param>
+    /// <param name="imageParams">Base image parameters.</param>
+    /// <param name="srcSetParams">SrcSet specific parameters that override imageParams.</param>
+    /// <returns>Media item URL.</returns>
+    public static string? GetMediaLink(this ImageField imageField, object? imageParams, object? srcSetParams)
+    {
+        ArgumentNullException.ThrowIfNull(imageField);
+        string? urlStr = imageField.Value.Src;
+
+        if (urlStr == null)
+        {
+            return null;
+        }
+
+        var mergedParams = MergeParameters(imageParams, srcSetParams);
+        return GetSitecoreMediaUri(urlStr, mergedParams);
+    }
+
+    /// <summary>
+    /// Merges base parameters with override parameters.
+    /// </summary>
+    /// <param name="baseParams">Base parameters.</param>
+    /// <param name="overrideParams">Override parameters that take precedence.</param>
+    /// <returns>Merged parameters as dictionary.</returns>
+    private static Dictionary<string, object?> MergeParameters(object? baseParams, object? overrideParams)
+    {
+        var result = new Dictionary<string, object?>();
+
+        // Add base parameters first
+        if (baseParams != null)
+        {
+            if (baseParams is Dictionary<string, object> baseDict)
+            {
+                foreach (var kvp in baseDict)
+                {
+                    result[kvp.Key] = kvp.Value;
+                }
+            }
+            else
+            {
+                var baseProps = baseParams.GetType().GetProperties();
+                foreach (var prop in baseProps)
+                {
+                    result[prop.Name] = prop.GetValue(baseParams);
+                }
+            }
+        }
+
+        // Override with srcSet parameters
+        if (overrideParams != null)
+        {
+            if (overrideParams is Dictionary<string, object> overrideDict)
+            {
+                foreach (var kvp in overrideDict)
+                {
+                    result[kvp.Key] = kvp.Value;
+                }
+            }
+            else
+            {
+                var overrideProps = overrideParams.GetType().GetProperties();
+                foreach (var prop in overrideProps)
+                {
+                    result[prop.Name] = prop.GetValue(overrideParams);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
     /// Gets URL to Sitecore media item.
     /// </summary>
     /// <param name="url">The image URL.</param>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using System.Web;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.WebUtilities;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
@@ -47,7 +48,29 @@ public static partial class SitecoreFieldExtensions
         }
 
         var mergedParams = MergeParameters(imageParams, srcSetParams);
-        return GetSitecoreMediaUri(urlStr, mergedParams);
+        return GetSitecoreMediaUriWithPreservation(urlStr, mergedParams);
+    }
+
+    /// <summary>
+    /// Gets modified URL string to Sitecore media item for srcSet with parameter preservation.
+    /// This method preserves critical Sitecore parameters needed for proper image processing.
+    /// </summary>
+    /// <param name="imageField">The image field.</param>
+    /// <param name="imageParams">Base image parameters.</param>
+    /// <param name="srcSetParams">SrcSet specific parameters that override imageParams.</param>
+    /// <returns>Media item URL.</returns>
+    public static string? GetMediaLinkForSrcSet(this ImageField imageField, object? imageParams, object? srcSetParams)
+    {
+        ArgumentNullException.ThrowIfNull(imageField);
+        string? urlStr = imageField.Value.Src;
+
+        if (urlStr == null)
+        {
+            return null;
+        }
+
+        var mergedParams = MergeParameters(imageParams, srcSetParams);
+        return GetSitecoreMediaUriWithPreservation(urlStr, mergedParams);
     }
 
     /// <summary>
@@ -97,6 +120,82 @@ public static partial class SitecoreFieldExtensions
                 {
                     result[prop.Name] = prop.GetValue(overrideParams);
                 }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Gets modified URL string to Sitecore media item with parameter preservation.
+    /// This preserves existing query parameters while adding new ones.
+    /// </summary>
+    /// <param name="url">Media item source URL.</param>
+    /// <param name="parameters">Additional parameters to merge with existing ones.</param>
+    /// <returns>Media item URL with preserved and merged parameters.</returns>
+    private static string GetSitecoreMediaUriWithPreservation(string url, object? parameters)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return url;
+        }
+
+        // Parse the existing URL to separate base URL and query string
+        var uri = new Uri(url);
+        var baseUrl = uri.GetLeftPart(UriPartial.Path);
+        var existingQuery = HttpUtility.ParseQueryString(uri.Query);
+
+        // Convert parameters to dictionary and merge with existing query parameters
+        var paramDict = ConvertToStringDictionary(parameters);
+        if (paramDict != null)
+        {
+            foreach (var param in paramDict)
+            {
+                existingQuery[param.Key] = param.Value;
+            }
+        }
+
+        // Apply the media URL prefix transformation (jssmedia replacement)
+        var finalBaseUrl = baseUrl;
+        Match match = MediaUrlPrefixRegex().Match(finalBaseUrl);
+        if (match.Success)
+        {
+            finalBaseUrl = finalBaseUrl.Replace(match.Value, $"/{match.Groups[1]}/jssmedia/", StringComparison.InvariantCulture);
+        }
+
+        // Build the final URL with merged parameters
+        var queryString = existingQuery.ToString();
+        return string.IsNullOrEmpty(queryString) ? finalBaseUrl : $"{finalBaseUrl}?{queryString}";
+    }
+
+    /// <summary>
+    /// Converts an object to a string dictionary.
+    /// </summary>
+    /// <param name="obj">The object to convert.</param>
+    /// <returns>Dictionary representation of the object.</returns>
+    private static Dictionary<string, string>? ConvertToStringDictionary(object? obj)
+    {
+        if (obj == null)
+        {
+            return null;
+        }
+
+        var result = new Dictionary<string, string>();
+
+        if (obj is Dictionary<string, object> dict)
+        {
+            foreach (var kvp in dict)
+            {
+                result[kvp.Key] = kvp.Value?.ToString() ?? string.Empty;
+            }
+        }
+        else
+        {
+            var props = obj.GetType().GetProperties();
+            foreach (var prop in props)
+            {
+                var value = prop.GetValue(obj);
+                result[prop.Name] = value?.ToString() ?? string.Empty;
             }
         }
 

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -36,7 +36,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
     private static string? GetWidthDescriptor(object parameters)
     {
         string? width = null;
-        
+
         // Handle Dictionary<string, object>
         if (parameters is Dictionary<string, object> dictionary)
         {
@@ -54,7 +54,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             // Handle anonymous objects via reflection
             var properties = parameters.GetType().GetProperties();
-            
+
             // Priority: w > mw (matching Content SDK behavior)
             var wProp = properties.FirstOrDefault(p => p.Name.Equals("w", StringComparison.OrdinalIgnoreCase));
             if (wProp != null)
@@ -391,8 +391,8 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 continue;
             }
 
-            // Use the new overload that merges ImageParams with srcSetItem params
-            string? mediaUrl = imageField.GetMediaLink(ImageParams, srcSetItem);
+            // Use GetMediaLinkForSrcSet to preserve existing URL parameters (like ttc, tt, hash, quality, format)
+            string? mediaUrl = imageField.GetMediaLinkForSrcSet(ImageParams, srcSetItem);
             if (!string.IsNullOrEmpty(mediaUrl))
             {
                 srcSetEntries.Add($"{mediaUrl} {descriptor}");

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -45,7 +45,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 {
                     return $"{kvp.Value}w";
                 }
-                
+
                 if (kvp.Key.Equals("w", StringComparison.OrdinalIgnoreCase) ||
                     kvp.Key.Equals("width", StringComparison.OrdinalIgnoreCase))
                 {
@@ -57,7 +57,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             // Handle anonymous objects via reflection
             var properties = parameters.GetType().GetProperties();
-            
+
             foreach (var prop in properties)
             {
                 if (prop.Name.Equals("mw", StringComparison.OrdinalIgnoreCase) ||
@@ -65,7 +65,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 {
                     return $"{prop.GetValue(parameters)}w";
                 }
-                
+
                 if (prop.Name.Equals("w", StringComparison.OrdinalIgnoreCase) ||
                     prop.Name.Equals("width", StringComparison.OrdinalIgnoreCase))
                 {
@@ -84,13 +84,13 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             return null;
         }
-        
+
         // If already an object array, use as-is
         if (srcSetValue is object[] objectArray)
         {
             return objectArray;
         }
-        
+
         // If it's a JSON string, parse it
         if (srcSetValue is string jsonString)
         {
@@ -105,7 +105,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 return null;
             }
         }
-        
+
         // Single object - wrap in array
         return new[] { srcSetValue };
     }
@@ -260,7 +260,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         if (!string.IsNullOrWhiteSpace(image.Src))
         {
             tagBuilder.Attributes.Add(ScrAttribute, imageField.GetMediaLink(ImageParams));
-            
+
             // Add srcset if configured
             if (SrcSet != null)
             {
@@ -354,7 +354,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
             }
 
             imageNode.SetAttributeValue(ScrAttribute, imageField.GetMediaLink(ImageParams));
-            
+
             // Add srcset for editable content
             if (SrcSet != null)
             {

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
@@ -798,7 +798,7 @@ public class ImageTagHelperFixture
         {
             EditableMarkup = "<img src=\"/sitecore/shell/-/jssmedia/img/sc_logo.png\" alt=\"Sitecore Logo\" />"
         };
-        
+
         tagHelperOutput.TagName = RenderingEngineConstants.SitecoreTagHelpers.ImageHtmlTag;
         sut.For = GetModelExpression(imageField);
         sut.SrcSet = new object[] { new { mw = 600 }, new { mw = 300 } };


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Apply the label "bug" or "enhancement" as applicable. -->

## Description / Motivation
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This PR implements responsive image support for the `ImageTagHelper` by adding `srcset` and `sizes` attribute functionality, enabling developers to output responsive images using Sitecore's built-in media resizing capabilities. The implementation matches the Content SDK (JSS replacement) behavior to ensure consistent output across .NET and JavaScript frameworks while addressing critical parameter preservation issues.

### Key Changes:

1. **Added `SrcSet` and `Sizes` Properties**: Extended the `ImageTagHelper` with new properties to support responsive image configuration for both `<sc-img>` and `<img>` tags.

2. **Multiple Input Format Support**: The `SrcSet` property accepts three different input formats for maximum flexibility:
   - **Anonymous objects**: `new object[] { new { w = 800 }, new { mw = 400 } }`
   - **Dictionary arrays**: `new Dictionary<string, object> { {"w", 800} }`
   - **JSON strings**: `[{"w": 800}, {"mw": 400}]` (most JSS-like syntax)

3. **Content SDK Parameter Priority**: Implements the same parameter precedence as Content SDK:
   - `w` (width) takes priority over `mw` (max width) for srcset descriptors
   - Extended support for legacy parameters: `w` > `mw` > `width` > `maxWidth`
   - Only entries with valid width parameters are included in srcset
   - Matches Content SDK's `getSrcSet` function behavior exactly

4. **Enhanced Parameter Merging with Preservation**: 
   - Base `imageParams` are merged with individual `srcSet` parameters
   - `srcSet` parameters override `imageParams` for each srcset entry
   - **Critical Fix**: Added `GetSitecoreMediaUriWithPreservation` method to preserve existing query parameters
   - Preserves essential Sitecore parameters (rev, db, la, vs, ts, hash, ttc, tt, etc.)
   - Follows Content SDK's `{ ...imageParams, ...params }` merge pattern

5. **Dual URL Processing Methods**: 
   - **Legacy `GetSitecoreMediaUri`**: Maintains existing behavior (strips query parameters)
   - **New `GetSitecoreMediaUriWithPreservation`**: Preserves critical parameters for responsive images
   - **`GetMediaLinkForSrcSet`**: Specialized method for srcSet URL generation with parameter preservation
   - Ensures backward compatibility while fixing responsive image display issues

6. **URL Transformation**: 
   - Transforms `/media/` URLs to `/jssmedia/` (Content SDK compatible)
   - Preserves cache-busting and required parameters using `HttpUtility.ParseQueryString`
   - Handles both XM Cloud and on-premise URL structures
   - Maintains media URL prefix regex pattern: `/([-~]{1})/media/`

7. **Enhanced HTML Output**: Generates proper HTML5 responsive image markup:
   ```html
   <img src="/~/jssmedia/image.jpg?h=386&iar=0&ttc=123&hash=ABC&quality=80" 
        srcset="/~/jssmedia/image.jpg?h=386&iar=0&ttc=123&hash=ABC&quality=80&w=800 800w, /~/jssmedia/image.jpg?h=386&iar=0&ttc=123&hash=ABC&quality=80&w=400 400w"
        sizes="(min-width: 768px) 800px, 400px"
        alt="..." />
   ```

8. **Experience Editor Support**: Works seamlessly with both normal rendering and Experience Editor editable markup.

9. **Backward Compatibility**: All existing functionality remains unchanged; new features are opt-in.

### Content SDK Compatibility:

The implementation now produces identical output to the Content SDK's `Image` component:

**Content SDK (React):**
```jsx
<Image 
  field={imageField} 
  imageParams={{quality: 80}} 
  srcSet={[{w: 800}, {mw: 400}]} 
  sizes="(min-width: 768px) 800px, 400px" 
/>
```

**ASP.NET Core SDK (Razor):**
```html
<sc-img asp-for="@Model.ImageField" 
        image-params='new { quality = 80 }'
        src-set='new object[] { new { w = 800 }, new { mw = 400 } }'
        sizes="(min-width: 768px) 800px, 400px" />
```

**Both produce identical HTML with preserved parameters:**
```html
<img src="/~/jssmedia/image.jpg?h=386&iar=0&ttc=123&hash=ABC&quality=80" 
     srcset="/~/jssmedia/image.jpg?h=386&iar=0&ttc=123&hash=ABC&quality=80&w=800 800w, /~/jssmedia/image.jpg?h=386&iar=0&ttc=123&hash=ABC&quality=80&w=400 400w"
     sizes="(min-width: 768px) 800px, 400px" 
     alt="Image" />
```

### Technical Implementation Details:

1. **Parameter Preservation Architecture**:
   - `MergeParameters()`: Merges base and override parameters using reflection and dictionary handling
   - `GetSitecoreMediaUriWithPreservation()`: Preserves existing URL parameters while adding new ones
   - `ConvertToStringDictionary()`: Converts objects to string dictionaries for URL building
   - `GetMediaLinkForSrcSet()`: Specialized extension method for responsive image URL generation

2. **JsonElement Handling**: Enhanced support for JSON deserialization scenarios to handle `JsonElement` types properly

3. **Helper Methods**: Added `AddResponsiveImageAttributes()` overloads to eliminate code duplication across `Process()`, `GenerateImage()`, and editable markup methods

### Usage Examples:

```html
<!-- Basic responsive image -->
<sc-img asp-for="@Model.HeroImage" 
        src-set='new object[] { new { w = 1200 }, new { w = 800 }, new { w = 400 } }'
        sizes="(min-width: 1200px) 1200px, (min-width: 800px) 800px, 400px" />

<!-- With base parameters (preserves existing URL params) -->
<img asp-for="@Model.ProductImage" 
     image-params='new { quality = 80, format = "webp" }'
     src-set='new object[] { new { w = 800, h = 600 }, new { mw = 400, mh = 300 } }'
     sizes="(min-width: 768px) 800px, 400px" />

<!-- JSON string format -->
@{
    string jsonSrcSet = """[{"w": 1000}, {"mw": 500}]""";
}
<sc-img asp-for="@Model.BannerImage" 
        src-set="@jsonSrcSet"
        sizes="(min-width: 960px) 1000px, 500px" />

<!-- Legacy parameter support -->
<sc-img asp-for="@Model.LegacyImage" 
        src-set='new object[] { new { width = 800 }, new { maxWidth = 400 } }'
        sizes="(min-width: 768px) 800px, 400px" />
```

This implementation ensures feature parity with the Content SDK while maintaining the familiar ASP.NET Core TagHelper syntax, full backward compatibility, and proper parameter preservation for functional image display.

## Testing

- [x] The Unit & Integration tests are passing.
- [x] I have added the necessary tests to cover my changes.
- [x] Added comprehensive test coverage for all three input formats
- [x] Added tests for Content SDK parameter priority (w > mw > width > maxWidth)
- [x] Added tests for parameter merging with imageParams and srcSet parameters
- [x] Added tests for cache-busting parameter preservation
- [x] Added tests for both `<sc-img>` and `<img>` tag scenarios
- [x] Added tests for Experience Editor editable markup integration
- [x] Added tests for entry filtering (only width-enabled parameters included)
- [x] Added tests for graceful fallback when invalid JSON is provided
- [x] Added tests for JsonElement handling in deserialization scenarios
- [x] Updated test expectations to match correct parameter preservation behavior

## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [x] I agree to follow this project's Code of Conduct.

Fix #16
