### PR TITLE
Updated - Enable SrcSet support with Content SDK Compatibility

### DIFF
--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -32,27 +32,6 @@ public static partial class SitecoreFieldExtensions
     }
 
     /// <summary>
-    /// Gets modified URL string to Sitecore media item with merged parameters.
-    /// </summary>
-    /// <param name="imageField">The image field.</param>
-    /// <param name="imageParams">Base image parameters.</param>
-    /// <param name="srcSetParams">SrcSet specific parameters that override imageParams.</param>
-    /// <returns>Media item URL.</returns>
-    public static string? GetMediaLink(this ImageField imageField, object? imageParams, object? srcSetParams)
-    {
-        ArgumentNullException.ThrowIfNull(imageField);
-        string? urlStr = imageField.Value.Src;
-
-        if (urlStr == null)
-        {
-            return null;
-        }
-
-        Dictionary<string, object?> mergedParams = MergeParameters(imageParams, srcSetParams);
-        return GetSitecoreMediaUriWithPreservation(urlStr, mergedParams);
-    }
-
-    /// <summary>
     /// Gets modified URL string to Sitecore media item for srcSet.
     /// This method preserves existing URL parameters and merges them with new ones.
     /// </summary>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -30,6 +30,80 @@ public static partial class SitecoreFieldExtensions
     }
 
     /// <summary>
+    /// Gets modified URL string to Sitecore media item with merged parameters.
+    /// </summary>
+    /// <param name="imageField">The image field.</param>
+    /// <param name="imageParams">Base image parameters.</param>
+    /// <param name="srcSetParams">SrcSet specific parameters that override imageParams.</param>
+    /// <returns>Media item URL.</returns>
+    public static string? GetMediaLink(this ImageField imageField, object? imageParams, object? srcSetParams)
+    {
+        ArgumentNullException.ThrowIfNull(imageField);
+        string? urlStr = imageField.Value.Src;
+
+        if (urlStr == null)
+        {
+            return null;
+        }
+
+        var mergedParams = MergeParameters(imageParams, srcSetParams);
+        return GetSitecoreMediaUri(urlStr, mergedParams);
+    }
+
+    /// <summary>
+    /// Merges base parameters with override parameters.
+    /// </summary>
+    /// <param name="baseParams">Base parameters.</param>
+    /// <param name="overrideParams">Override parameters that take precedence.</param>
+    /// <returns>Merged parameters as dictionary.</returns>
+    private static Dictionary<string, object?> MergeParameters(object? baseParams, object? overrideParams)
+    {
+        var result = new Dictionary<string, object?>();
+
+        // Add base parameters first
+        if (baseParams != null)
+        {
+            if (baseParams is Dictionary<string, object> baseDict)
+            {
+                foreach (var kvp in baseDict)
+                {
+                    result[kvp.Key] = kvp.Value;
+                }
+            }
+            else
+            {
+                var baseProps = baseParams.GetType().GetProperties();
+                foreach (var prop in baseProps)
+                {
+                    result[prop.Name] = prop.GetValue(baseParams);
+                }
+            }
+        }
+
+        // Override with srcSet parameters
+        if (overrideParams != null)
+        {
+            if (overrideParams is Dictionary<string, object> overrideDict)
+            {
+                foreach (var kvp in overrideDict)
+                {
+                    result[kvp.Key] = kvp.Value;
+                }
+            }
+            else
+            {
+                var overrideProps = overrideParams.GetType().GetProperties();
+                foreach (var prop in overrideProps)
+                {
+                    result[prop.Name] = prop.GetValue(overrideParams);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
     /// Gets URL to Sitecore media item.
     /// </summary>
     /// <param name="url">The image URL.</param>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using System.Web;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.WebUtilities;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
@@ -47,7 +48,29 @@ public static partial class SitecoreFieldExtensions
         }
 
         var mergedParams = MergeParameters(imageParams, srcSetParams);
-        return GetSitecoreMediaUri(urlStr, mergedParams);
+        return GetSitecoreMediaUriWithPreservation(urlStr, mergedParams);
+    }
+
+    /// <summary>
+    /// Gets modified URL string to Sitecore media item for srcSet with parameter preservation.
+    /// This method preserves critical Sitecore parameters needed for proper image processing.
+    /// </summary>
+    /// <param name="imageField">The image field.</param>
+    /// <param name="imageParams">Base image parameters.</param>
+    /// <param name="srcSetParams">SrcSet specific parameters that override imageParams.</param>
+    /// <returns>Media item URL.</returns>
+    public static string? GetMediaLinkForSrcSet(this ImageField imageField, object? imageParams, object? srcSetParams)
+    {
+        ArgumentNullException.ThrowIfNull(imageField);
+        string? urlStr = imageField.Value.Src;
+
+        if (urlStr == null)
+        {
+            return null;
+        }
+
+        var mergedParams = MergeParameters(imageParams, srcSetParams);
+        return GetSitecoreMediaUriWithPreservation(urlStr, mergedParams);
     }
 
     /// <summary>
@@ -97,6 +120,82 @@ public static partial class SitecoreFieldExtensions
                 {
                     result[prop.Name] = prop.GetValue(overrideParams);
                 }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Gets modified URL string to Sitecore media item with parameter preservation.
+    /// This preserves existing query parameters while adding new ones.
+    /// </summary>
+    /// <param name="url">Media item source URL.</param>
+    /// <param name="parameters">Additional parameters to merge with existing ones.</param>
+    /// <returns>Media item URL with preserved and merged parameters.</returns>
+    private static string GetSitecoreMediaUriWithPreservation(string url, object? parameters)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return url;
+        }
+
+        // Parse the existing URL to separate base URL and query string
+        var uri = new Uri(url);
+        var baseUrl = uri.GetLeftPart(UriPartial.Path);
+        var existingQuery = HttpUtility.ParseQueryString(uri.Query);
+
+        // Convert parameters to dictionary and merge with existing query parameters
+        var paramDict = ConvertToStringDictionary(parameters);
+        if (paramDict != null)
+        {
+            foreach (var param in paramDict)
+            {
+                existingQuery[param.Key] = param.Value;
+            }
+        }
+
+        // Apply the media URL prefix transformation (jssmedia replacement)
+        var finalBaseUrl = baseUrl;
+        Match match = MediaUrlPrefixRegex().Match(finalBaseUrl);
+        if (match.Success)
+        {
+            finalBaseUrl = finalBaseUrl.Replace(match.Value, $"/{match.Groups[1]}/jssmedia/", StringComparison.InvariantCulture);
+        }
+
+        // Build the final URL with merged parameters
+        var queryString = existingQuery.ToString();
+        return string.IsNullOrEmpty(queryString) ? finalBaseUrl : $"{finalBaseUrl}?{queryString}";
+    }
+
+    /// <summary>
+    /// Converts an object to a string dictionary.
+    /// </summary>
+    /// <param name="obj">The object to convert.</param>
+    /// <returns>Dictionary representation of the object.</returns>
+    private static Dictionary<string, string>? ConvertToStringDictionary(object? obj)
+    {
+        if (obj == null)
+        {
+            return null;
+        }
+
+        var result = new Dictionary<string, string>();
+
+        if (obj is Dictionary<string, object> dict)
+        {
+            foreach (var kvp in dict)
+            {
+                result[kvp.Key] = kvp.Value?.ToString() ?? string.Empty;
+            }
+        }
+        else
+        {
+            var props = obj.GetType().GetProperties();
+            foreach (var prop in props)
+            {
+                var value = prop.GetValue(obj);
+                result[prop.Name] = value?.ToString() ?? string.Empty;
             }
         }
 

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -141,9 +141,9 @@ public static partial class SitecoreFieldExtensions
         }
 
         // Parse the existing URL to separate base URL and query string
-        var uri = new Uri(url);
+        var uri = new Uri(url, UriKind.RelativeOrAbsolute);
         var baseUrl = uri.GetLeftPart(UriPartial.Path);
-        var existingQuery = HttpUtility.ParseQueryString(uri.Query);
+        var existingQuery = QueryHelpers.ParseQuery(uri.Query);
 
         // Convert parameters to dictionary and merge with existing query parameters
         var paramDict = ConvertToStringDictionary(parameters);
@@ -151,6 +151,7 @@ public static partial class SitecoreFieldExtensions
         {
             foreach (var param in paramDict)
             {
+                // QueryHelpers.ParseQuery returns StringValues, so we need to handle this properly
                 existingQuery[param.Key] = param.Value;
             }
         }
@@ -164,8 +165,8 @@ public static partial class SitecoreFieldExtensions
         }
 
         // Build the final URL with merged parameters
-        var queryString = existingQuery.ToString();
-        return string.IsNullOrEmpty(queryString) ? finalBaseUrl : $"{finalBaseUrl}?{queryString}";
+        var queryString = QueryHelpers.AddQueryString(string.Empty, existingQuery.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToString()));
+        return queryString.StartsWith("?") ? $"{finalBaseUrl}{queryString}" : finalBaseUrl;
     }
 
     /// <summary>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -34,8 +34,13 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
     private const string SizesAttribute = "sizes";
     private readonly IEditableChromeRenderer _chromeRenderer = chromeRenderer ?? throw new ArgumentNullException(nameof(chromeRenderer));
 
-    private static string? GetWidthDescriptor(object parameters)
+    private static string? GetWidthDescriptor(object? parameters)
     {
+        if (parameters == null)
+        {
+            return null;
+        }
+
         string? width = null;
 
         // Handle Dictionary<string, object>
@@ -50,13 +55,13 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
             {
                 width = mwValue?.ToString();
             }
-            else if (dictionary.TryGetValue("width", out object? widthValue))
+            else if (dictionary.TryGetValue("width", out object? widthObj))
             {
-                width = widthValue?.ToString();
+                width = widthObj?.ToString();
             }
-            else if (dictionary.TryGetValue("maxWidth", out object? maxWidthValue))
+            else if (dictionary.TryGetValue("maxWidth", out object? maxWidthObj))
             {
-                width = maxWidthValue?.ToString();
+                width = maxWidthObj?.ToString();
             }
         }
         else
@@ -94,6 +99,12 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                     }
                 }
             }
+        }
+
+        // Validate width is positive
+        if (width != null && int.TryParse(width, out int widthValue) && widthValue <= 0)
+        {
+            return null;
         }
 
         return width != null ? $"{width}w" : null;
@@ -408,6 +419,12 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 
         foreach (object srcSetItem in parsedSrcSet)
         {
+            // Skip null items
+            if (srcSetItem == null)
+            {
+                continue;
+            }
+
             // Get width descriptor first to check if this entry should be included
             string? descriptor = GetWidthDescriptor(srcSetItem);
             if (descriptor == null)

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -36,7 +36,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
     private static string? GetWidthDescriptor(object parameters)
     {
         string? width = null;
-        
+
         // Handle Dictionary<string, object>
         if (parameters is Dictionary<string, object> dictionary)
         {
@@ -54,7 +54,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             // Handle anonymous objects via reflection
             var properties = parameters.GetType().GetProperties();
-            
+
             // Priority: w > mw (matching Content SDK behavior)
             var wProp = properties.FirstOrDefault(p => p.Name.Equals("w", StringComparison.OrdinalIgnoreCase));
             if (wProp != null)
@@ -391,8 +391,8 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 continue;
             }
 
-            // Use the new overload that merges ImageParams with srcSetItem params
-            string? mediaUrl = imageField.GetMediaLink(ImageParams, srcSetItem);
+            // Use GetMediaLinkForSrcSet to preserve existing URL parameters (like ttc, tt, hash, quality, format)
+            string? mediaUrl = imageField.GetMediaLinkForSrcSet(ImageParams, srcSetItem);
             if (!string.IsNullOrEmpty(mediaUrl))
             {
                 srcSetEntries.Add($"{mediaUrl} {descriptor}");

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -1,4 +1,5 @@
-﻿using HtmlAgilityPack;
+﻿using System.Reflection;
+using HtmlAgilityPack;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
@@ -61,31 +62,31 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         else
         {
             // Handle anonymous objects via reflection
-            var properties = parameters.GetType().GetProperties();
+            PropertyInfo[] properties = parameters.GetType().GetProperties();
 
             // Priority: w > mw > width > maxWidth (matching Content SDK behavior + legacy support)
-            var wProp = properties.FirstOrDefault(p => p.Name.Equals("w", StringComparison.OrdinalIgnoreCase));
+            PropertyInfo? wProp = properties.FirstOrDefault(p => p.Name.Equals("w", StringComparison.OrdinalIgnoreCase));
             if (wProp != null)
             {
                 width = wProp.GetValue(parameters)?.ToString();
             }
             else
             {
-                var mwProp = properties.FirstOrDefault(p => p.Name.Equals("mw", StringComparison.OrdinalIgnoreCase));
+                PropertyInfo? mwProp = properties.FirstOrDefault(p => p.Name.Equals("mw", StringComparison.OrdinalIgnoreCase));
                 if (mwProp != null)
                 {
                     width = mwProp.GetValue(parameters)?.ToString();
                 }
                 else
                 {
-                    var widthProp = properties.FirstOrDefault(p => p.Name.Equals("width", StringComparison.OrdinalIgnoreCase));
+                    PropertyInfo? widthProp = properties.FirstOrDefault(p => p.Name.Equals("width", StringComparison.OrdinalIgnoreCase));
                     if (widthProp != null)
                     {
                         width = widthProp.GetValue(parameters)?.ToString();
                     }
                     else
                     {
-                        var maxWidthProp = properties.FirstOrDefault(p => p.Name.Equals("maxWidth", StringComparison.OrdinalIgnoreCase));
+                        PropertyInfo? maxWidthProp = properties.FirstOrDefault(p => p.Name.Equals("maxWidth", StringComparison.OrdinalIgnoreCase));
                         if (maxWidthProp != null)
                         {
                             width = maxWidthProp.GetValue(parameters)?.ToString();
@@ -116,7 +117,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             try
             {
-                var parsed = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>[]>(jsonString);
+                Dictionary<string, object>[]? parsed = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>[]>(jsonString);
                 return parsed?.Cast<object>().ToArray();
             }
             catch (System.Text.Json.JsonException)

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
@@ -920,6 +920,275 @@ public class ImageTagHelperFixture
         tagHelperOutput.Attributes.Should().NotContain(a => a.Name == "srcset");
     }
 
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithImageParamsConflict_SrcSetParametersWin(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(_image));
+        sut.ImageParams = new { w = 1000, quality = 50, format = "jpg" };
+        sut.SrcSet = new object[] { new { w = 320, quality = 75 } };
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
+        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
+        srcSetValue.Should().Contain("w=320");
+        srcSetValue.Should().Contain("quality=75");
+        srcSetValue.Should().Contain("format=jpg"); // Inherited from ImageParams
+        srcSetValue.Should().NotContain("w=1000");
+        srcSetValue.Should().NotContain("quality=50");
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithWidthParameterPriority_UsesCorrectPrecedence(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange - Test priority: w > mw > width > maxWidth
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(_image));
+        sut.SrcSet = new object[]
+        {
+            new { w = 100, mw = 200, width = 300, maxWidth = 400 }, // Should use w=100
+            new { mw = 200, width = 300, maxWidth = 400 }, // Should use mw=200
+            new { width = 300, maxWidth = 400 }, // Should use width=300
+            new { maxWidth = 400 } // Should use maxWidth=400
+        };
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
+        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
+        srcSetValue.Should().Contain("100w");
+        srcSetValue.Should().Contain("200w");
+        srcSetValue.Should().Contain("300w");
+        srcSetValue.Should().Contain("400w");
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithZeroOrNegativeWidths_SkipsInvalidEntries(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(_image));
+        sut.SrcSet = new object[]
+        {
+            new { w = 0, quality = 75 },    // Should skip
+            new { w = -100, quality = 80 }, // Should skip
+            new { w = 320, quality = 75 },  // Should include
+            new { quality = 90 } // Should skip - no width
+        };
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
+        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
+        srcSetValue.Should().Contain("320w");
+        srcSetValue.Should().NotContain(" 0w");
+        srcSetValue.Should().NotContain(" -100w");
+
+        // Should only have one entry
+        string[] entries = srcSetValue.Split(", ");
+        entries.Should().HaveCount(1);
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithExistingUrlParameters_PreservesAndMergesParameters(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        Image imageWithParams = new Image
+        {
+            Src = "https://edge.sitecorecloud.io/media/image.jpg?h=2001&iar=0&hash=abc123&w=3000",
+            Alt = "Test Image"
+        };
+
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(imageWithParams));
+        sut.SrcSet = new object[] { new { w = 320, quality = 75 } };
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
+        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
+
+        // Should preserve existing parameters and merge with new ones
+        srcSetValue.Should().Contain("h=2001");
+        srcSetValue.Should().Contain("iar=0");
+        srcSetValue.Should().Contain("hash=abc123");
+        srcSetValue.Should().Contain("quality=75");
+
+        // New w parameter should override existing w=3000
+        srcSetValue.Should().Contain("w=320");
+        srcSetValue.Should().NotContain("w=3000");
+        srcSetValue.Should().Contain("320w");
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithMediaUrlTransformation_TransformsCorrectly(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        Image imageWithMediaUrl = new Image
+        {
+            Src = "/~/media/images/test.jpg",
+            Alt = "Test Image"
+        };
+
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(imageWithMediaUrl));
+        sut.SrcSet = new object[] { new { w = 320, quality = 75 } };
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
+        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
+
+        // Should transform /~/media/ to /~/jssmedia/
+        srcSetValue.Should().Contain("/~/jssmedia/images/test.jpg");
+        srcSetValue.Should().NotContain("/~/media/images/test.jpg");
+        srcSetValue.Should().Contain("320w");
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithNullAndEmptyEntries_HandlesGracefully(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(_image));
+        sut.SrcSet = new object?[]
+        {
+            new { w = 320, quality = 75 },
+            null, // Should skip
+            new { w = 480, quality = 80 },
+            new { } // Should skip - no width parameter
+        };
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
+        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
+        srcSetValue.Should().Contain("320w");
+        srcSetValue.Should().Contain("480w");
+
+        // Should only have two entries
+        string[] entries = srcSetValue.Split(", ");
+        entries.Should().HaveCount(2);
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithComplexParameters_HandlesAllParameters(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(_image));
+        sut.SrcSet = new object[]
+        {
+            new { w = 320, quality = 75, format = "webp", dpr = 2, fit = "crop" }
+        };
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
+        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
+        srcSetValue.Should().Contain("320w");
+        srcSetValue.Should().Contain("quality=75");
+        srcSetValue.Should().Contain("format=webp");
+        srcSetValue.Should().Contain("dpr=2");
+        srcSetValue.Should().Contain("fit=crop");
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithDictionaryParameters_GeneratesSrcSetAttribute(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(_image));
+        sut.SrcSet = new object[]
+        {
+            new Dictionary<string, object> { { "w", 320 }, { "quality", 75 } },
+            new Dictionary<string, object> { { "mw", 480 }, { "quality", 80 } }
+        };
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
+        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
+        srcSetValue.Should().Contain("320w");
+        srcSetValue.Should().Contain("480w");
+        srcSetValue.Should().Contain("quality=75");
+        srcSetValue.Should().Contain("quality=80");
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithSizesAttribute_AddsBothAttributes(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(_image));
+        sut.SrcSet = new object[] { new { w = 320 }, new { w = 480 } };
+        sut.Sizes = "(min-width: 768px) 480px, 320px";
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().Contain(a => a.Name == "srcset");
+        tagHelperOutput.Attributes.Should().Contain(a => a.Name == "sizes");
+
+        string sizesValue = tagHelperOutput.Attributes["sizes"].Value.ToString()!;
+        sizesValue.Should().Be("(min-width: 768px) 480px, 320px");
+    }
+
     private static ModelExpression GetModelExpression(Field model)
     {
         DefaultModelMetadata? modelMetadata = Substitute.For<DefaultModelMetadata>(

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
@@ -780,14 +780,15 @@ public class ImageTagHelperFixture
         // Assert
         tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
         string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
-        
+
         // Should contain "1000w" (from w parameter taking priority over h)
         srcSetValue.Should().Contain("1000w");
+
         // Should contain "250w" (from mw parameter)
         srcSetValue.Should().Contain("250w");
-        
+
         // Verify it contains the expected format: "url 1000w, url 250w"
-        var entries = srcSetValue.Split(", ");
+        string[] entries = srcSetValue.Split(", ");
         entries.Should().HaveCount(2);
         entries[0].Should().EndWith("1000w");
         entries[1].Should().EndWith("250w");
@@ -811,11 +812,12 @@ public class ImageTagHelperFixture
         // Assert
         tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
         string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
-        
+
         // Should only contain the entry with mw parameter
         srcSetValue.Should().Contain("250w");
+
         // Should not contain entries without width parameters
-        var entries = srcSetValue.Split(", ");
+        string[] entries = srcSetValue.Split(", ");
         entries.Should().HaveCount(1);
     }
 
@@ -883,9 +885,9 @@ public class ImageTagHelperFixture
         sut.For = GetModelExpression(new ImageField(_image));
         sut.SrcSet = new object[]
         {
+            // Only w and mw are supported by Content SDK for srcSet
             new { w = 800 },  // Anonymous object with 'w'
             new { mw = 400 }, // Anonymous object with 'mw'
-            // Only w and mw are supported by Content SDK for srcSet
         };
 
         // Act


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Apply the label "bug" or "enhancement" as applicable. -->

## Description / Motivation
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This PR implements responsive image support for the `ImageTagHelper` by adding `srcset` and `sizes` attribute functionality, enabling developers to output responsive images using Sitecore's built-in media resizing capabilities. The implementation matches the Content SDK (JSS replacement) behavior to ensure consistent output across .NET and JavaScript frameworks while addressing critical parameter preservation issues.

### Key Changes:

1. **Added `SrcSet` and `Sizes` Properties**: Extended the `ImageTagHelper` with new properties to support responsive image configuration for both `<sc-img>` and `<img>` tags.

2. **Multiple Input Format Support**: The `SrcSet` property accepts three different input formats for maximum flexibility:
   - **Anonymous objects**: `new object[] { new { w = 800 }, new { mw = 400 } }`
   - **Dictionary arrays**: `new Dictionary<string, object> { {"w", 800} }`
   - **JSON strings**: `[{"w": 800}, {"mw": 400}]` (most JSS-like syntax)

3. **Content SDK Parameter Priority**: Implements the same parameter precedence as Content SDK:
   - `w` (width) takes priority over `mw` (max width) for srcset descriptors
   - Extended support for legacy parameters: `w` > `mw` > `width` > `maxWidth`
   - Only entries with valid width parameters are included in srcset
   - Matches Content SDK's `getSrcSet` function behavior exactly

4. **Enhanced Parameter Merging with Preservation**: 
   - Base `imageParams` are merged with individual `srcSet` parameters
   - `srcSet` parameters override `imageParams` for each srcset entry
   - **Critical Fix**: Added `GetSitecoreMediaUriWithPreservation` method to preserve existing query parameters
   - Preserves essential Sitecore parameters (rev, db, la, vs, ts, hash, ttc, tt, etc.)
   - Follows Content SDK's `{ ...imageParams, ...params }` merge pattern

5. **Dual URL Processing Methods**: 
   - **Legacy `GetSitecoreMediaUri`**: Maintains existing behavior (strips query parameters)
   - **New `GetSitecoreMediaUriWithPreservation`**: Preserves critical parameters for responsive images
   - **`GetMediaLinkForSrcSet`**: Specialized method for srcSet URL generation with parameter preservation
   - Ensures backward compatibility while fixing responsive image display issues

6. **URL Transformation**: 
   - Transforms `/media/` URLs to `/jssmedia/` (Content SDK compatible)
   - Preserves cache-busting and required parameters using `HttpUtility.ParseQueryString`
   - Handles both XM Cloud and on-premise URL structures
   - Maintains media URL prefix regex pattern: `/([-~]{1})/media/`

7. **Enhanced HTML Output**: Generates proper HTML5 responsive image markup:
   ```html
   <img src="/~/jssmedia/image.jpg?h=386&iar=0&ttc=123&hash=ABC&quality=80" 
        srcset="/~/jssmedia/image.jpg?h=386&iar=0&ttc=123&hash=ABC&quality=80&w=800 800w, /~/jssmedia/image.jpg?h=386&iar=0&ttc=123&hash=ABC&quality=80&w=400 400w"
        sizes="(min-width: 768px) 800px, 400px"
        alt="..." />
   ```

8. **Experience Editor Support**: Works seamlessly with both normal rendering and Experience Editor editable markup.

9. **Backward Compatibility**: All existing functionality remains unchanged; new features are opt-in.

### Content SDK Compatibility:

The implementation now produces identical output to the Content SDK's `Image` component:

**Content SDK (React):**
```jsx
<Image 
  field={imageField} 
  imageParams={{quality: 80}} 
  srcSet={[{w: 800}, {mw: 400}]} 
  sizes="(min-width: 768px) 800px, 400px" 
/>
```

**ASP.NET Core SDK (Razor):**
```html
<sc-img asp-for="@Model.ImageField" 
        image-params='new { quality = 80 }'
        src-set='new object[] { new { w = 800 }, new { mw = 400 } }'
        sizes="(min-width: 768px) 800px, 400px" />
```

**Both produce identical HTML with preserved parameters:**
```html
<img src="/~/jssmedia/image.jpg?h=386&iar=0&ttc=123&hash=ABC&quality=80" 
     srcset="/~/jssmedia/image.jpg?h=386&iar=0&ttc=123&hash=ABC&quality=80&w=800 800w, /~/jssmedia/image.jpg?h=386&iar=0&ttc=123&hash=ABC&quality=80&w=400 400w"
     sizes="(min-width: 768px) 800px, 400px" 
     alt="Image" />
```

### Technical Implementation Details:

1. **Parameter Preservation Architecture**:
   - `MergeParameters()`: Merges base and override parameters using reflection and dictionary handling
   - `GetSitecoreMediaUriWithPreservation()`: Preserves existing URL parameters while adding new ones
   - `ConvertToStringDictionary()`: Converts objects to string dictionaries for URL building
   - `GetMediaLinkForSrcSet()`: Specialized extension method for responsive image URL generation

2. **JsonElement Handling**: Enhanced support for JSON deserialization scenarios to handle `JsonElement` types properly

3. **Helper Methods**: Added `AddResponsiveImageAttributes()` overloads to eliminate code duplication across `Process()`, `GenerateImage()`, and editable markup methods

### Usage Examples:

```html
<!-- Basic responsive image -->
<sc-img asp-for="@Model.HeroImage" 
        src-set='new object[] { new { w = 1200 }, new { w = 800 }, new { w = 400 } }'
        sizes="(min-width: 1200px) 1200px, (min-width: 800px) 800px, 400px" />

<!-- With base parameters (preserves existing URL params) -->
<img asp-for="@Model.ProductImage" 
     image-params='new { quality = 80, format = "webp" }'
     src-set='new object[] { new { w = 800, h = 600 }, new { mw = 400, mh = 300 } }'
     sizes="(min-width: 768px) 800px, 400px" />

<!-- JSON string format -->
@{
    string jsonSrcSet = """[{"w": 1000}, {"mw": 500}]""";
}
<sc-img asp-for="@Model.BannerImage" 
        src-set="@jsonSrcSet"
        sizes="(min-width: 960px) 1000px, 500px" />

<!-- Legacy parameter support -->
<sc-img asp-for="@Model.LegacyImage" 
        src-set='new object[] { new { width = 800 }, new { maxWidth = 400 } }'
        sizes="(min-width: 768px) 800px, 400px" />
```

This implementation ensures feature parity with the Content SDK while maintaining the familiar ASP.NET Core TagHelper syntax, full backward compatibility, and proper parameter preservation for functional image display.

## Testing

- [x] The Unit & Integration tests are passing.
- [x] I have added the necessary tests to cover my changes.

## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [x] I agree to follow this project's Code of Conduct.

Fix #16
