### PR TITLE
Refactor ImageTagHelper Parameter Extraction and Remove JSON SrcSet Support - Code changes of the PR Review

### DIFF
--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -176,28 +176,27 @@ public static partial class SitecoreFieldExtensions
     /// <returns>The URL without query parameters.</returns>
     private static string ParseUrlParams(string url, Dictionary<string, object?> parameters)
     {
-        if (url.Contains('?'))
+        if (string.IsNullOrEmpty(url))
         {
-            string[] parts = url.Split('?', 2);
-            string cleanUrl = parts[0];
-            string queryString = parts[1];
-
-            string[] paramPairs = queryString.Split('&');
-            foreach (string paramPair in paramPairs)
-            {
-                string[] keyValue = paramPair.Split('=', 2);
-                if (keyValue.Length == 2)
-                {
-                    string key = HttpUtility.UrlDecode(keyValue[0]);
-                    string value = HttpUtility.UrlDecode(keyValue[1]);
-                    parameters[key] = value;
-                }
-            }
-
-            return cleanUrl;
+            return url;
         }
 
-        return url;
+        int queryIndex = url.IndexOf('?');
+        if (queryIndex < 0)
+        {
+            return url;
+        }
+
+        string cleanUrl = url.Substring(0, queryIndex);
+        string queryString = url.Substring(queryIndex);
+
+        Dictionary<string, Microsoft.Extensions.Primitives.StringValues> parsedQuery = QueryHelpers.ParseQuery(queryString);
+        foreach (KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues> kvp in parsedQuery)
+        {
+            parameters[kvp.Key] = kvp.Value.Count > 0 ? kvp.Value[0] : null;
+        }
+
+        return cleanUrl;
     }
 
     /// <summary>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -97,13 +97,12 @@ public static partial class SitecoreFieldExtensions
         }
         else
         {
-            PropertyInfo[] properties = parameters.GetType().GetProperties();
-            foreach (PropertyInfo prop in properties)
+            RouteValueDictionary routeValues = new RouteValueDictionary(parameters);
+            foreach (KeyValuePair<string, object?> kvp in routeValues)
             {
-                object? value = prop.GetValue(parameters);
-                if (!skipNullValues || value != null)
+                if (!skipNullValues || kvp.Value != null)
                 {
-                    result[prop.Name] = value;
+                    result[kvp.Key] = kvp.Value;
                 }
             }
         }

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -191,21 +191,21 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         if (parameters is Dictionary<string, object> dictionary)
         {
             // Priority: w > mw > width > maxWidth (matching Content SDK behavior + legacy support)
-            if (dictionary.ContainsKey("w"))
+            if (dictionary.TryGetValue("w", out var wValue))
             {
-                width = dictionary["w"]?.ToString();
+                width = wValue.ToString();
             }
-            else if (dictionary.ContainsKey("mw"))
+            else if (dictionary.TryGetValue("mw", out var mwValue))
             {
-                width = dictionary["mw"]?.ToString();
+                width = mwValue.ToString();
             }
-            else if (dictionary.ContainsKey("width"))
+            else if (dictionary.TryGetValue("width", out var widthValue))
             {
-                width = dictionary["width"]?.ToString();
+                width = widthValue.ToString();
             }
-            else if (dictionary.ContainsKey("maxWidth"))
+            else if (dictionary.TryGetValue("maxWidth", out var maxWidthValue))
             {
-                width = dictionary["maxWidth"]?.ToString();
+                width = maxWidthValue.ToString();
             }
         }
         else
@@ -219,7 +219,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 ?? TryParseParameter(parameters, "maxWidth", properties);
         }
 
-        if (width != null && int.TryParse(width, out int widthValue) && widthValue <= 0)
+        if (width != null && int.TryParse(width, out int widthValueInt) && widthValueInt <= 0)
         {
             return null;
         }

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
@@ -863,29 +863,6 @@ public class ImageTagHelperFixture
 
     [Theory]
     [AutoNSubstituteData]
-    public void Process_SrcSetWithJsonString_GeneratesSrcSetAttribute(
-        ImageTagHelper sut,
-        TagHelperContext tagHelperContext,
-        TagHelperOutput tagHelperOutput)
-    {
-        // Arrange
-        tagHelperOutput.TagName = "img";
-        sut.For = GetModelExpression(new ImageField(_image));
-        sut.SrcSet = "[{\"mw\": 500}, {\"mw\": 250}]";
-
-        // Act
-        sut.Process(tagHelperContext, tagHelperOutput);
-
-        // Assert
-        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
-        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
-
-        // Full string comparison
-        srcSetValue.Should().Be("http://styleguide/-/jssmedia/styleguide/data/media/img/sc_logo.png?iar=0&hash=F313AD90AE547CAB09277E42509E289B&mw=500 500w, http://styleguide/-/jssmedia/styleguide/data/media/img/sc_logo.png?iar=0&hash=F313AD90AE547CAB09277E42509E289B&mw=250 250w");
-    }
-
-    [Theory]
-    [AutoNSubstituteData]
     public void Process_SrcSetWithMixedParameterTypes_GeneratesSrcSetAttribute(
         ImageTagHelper sut,
         TagHelperContext tagHelperContext,
@@ -913,25 +890,6 @@ public class ImageTagHelperFixture
 
         // Full string comparison
         srcsetValue.Should().Be("http://styleguide/-/jssmedia/styleguide/data/media/img/sc_logo.png?iar=0&amp;hash=F313AD90AE547CAB09277E42509E289B&amp;w=800 800w, http://styleguide/-/jssmedia/styleguide/data/media/img/sc_logo.png?iar=0&amp;hash=F313AD90AE547CAB09277E42509E289B&amp;mw=400 400w");
-    }
-
-    [Theory]
-    [AutoNSubstituteData]
-    public void Process_SrcSetWithInvalidJsonString_ThrowsInvalidOperationException(
-        ImageTagHelper sut,
-        TagHelperContext tagHelperContext,
-        TagHelperOutput tagHelperOutput)
-    {
-        // Arrange
-        tagHelperOutput.TagName = "img";
-        sut.For = GetModelExpression(new ImageField(_image));
-        sut.SrcSet = "invalid json string";
-
-        // Act & Assert
-        Action act = () => sut.Process(tagHelperContext, tagHelperOutput);
-        act.Should().Throw<InvalidOperationException>()
-           .WithMessage("Failed to parse srcset JSON: invalid json string*")
-           .WithInnerException<System.Text.Json.JsonException>();
     }
 
     [Theory]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Apply the label "bug" or "enhancement" as applicable. -->

## Description / Motivation
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->


This PR addresses feedback from code review and includes several refactorings and improvements for parameter extraction and handling in the ImageTagHelper and related utilities,

- **Refactored `AddParametersToResult`** to use `RouteValueDictionary` for extracting object properties, improving consistency and maintainability.
- **Updated `ParseUrlParams`** to use `QueryHelpers.ParseQuery` for extracting query parameters from URLs, ensuring more robust and reliable parsing.
- **Refactored `GetWidthDescriptor`** to use `TryGetValue` instead of `ContainsKey` for CA1854 compliance, improving performance and code clarity.
- **Removed JSON string support for `SrcSet`** in `ImageTagHelper` and updated related tests to reflect this change.

## Testing

- [x] The Unit & Intergration tests are passing.
- [x] I have added the necessary tests to cover my changes.

## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md).
