### PR TITLE
migrate from FluentAssertions to AwesomeAssertions - ASP.NET-Core-SDK

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,8 +23,8 @@
     <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="FluentAssertions.Analyzers" Version="0.32.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.1.0" />
+    <PackageVersion Include="AwesomeAssertions.Analyzers" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />

--- a/tests/Sitecore.AspNetCore.SDK.AutoFixture/Sitecore.AspNetCore.SDK.AutoFixture.csproj
+++ b/tests/Sitecore.AspNetCore.SDK.AutoFixture/Sitecore.AspNetCore.SDK.AutoFixture.csproj
@@ -8,8 +8,11 @@
     <PackageReference Include="AutoFixture.AutoNSubstitute" />
     <PackageReference Include="AutoFixture.Idioms" />
     <PackageReference Include="AutoFixture.Xunit2" />
-    <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="FluentAssertions.Analyzers" />
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="AwesomeAssertions.Analyzers">
+    <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" />
     <PackageReference Include="xunit" />

--- a/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/Configuration/ExperienceEditorOptionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/Configuration/ExperienceEditorOptionsFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture.Xunit2;
-using FluentAssertions;
+using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.ExperienceEditor.Configuration;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/Extensions/ApplicationBuilderExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/Extensions/ApplicationBuilderExtensionsFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Builder;
 using NSubstitute;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;

--- a/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/Extensions/ServiceCollectionExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/Extensions/ServiceCollectionExtensionsFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.ExperienceEditor.Extensions;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Interfaces;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/Mappers/SitecoreLayoutResponseMapperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/Mappers/SitecoreLayoutResponseMapperFixture.cs
@@ -1,7 +1,7 @@
 ﻿using AutoFixture;
 using AutoFixture.Idioms;
 using AutoFixture.Xunit2;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/Middleware/ExperienceEditorMiddlewareFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/Middleware/ExperienceEditorMiddlewareFixture.cs
@@ -2,7 +2,7 @@
 using AutoFixture;
 using AutoFixture.Idioms;
 using AutoFixture.Xunit2;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;

--- a/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/Models/ExperienceEditorPostModelFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/Models/ExperienceEditorPostModelFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;
 using Sitecore.AspNetCore.SDK.ExperienceEditor.Models;

--- a/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/TagHelpers/ChromeDataBuilderFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/TagHelpers/ChromeDataBuilderFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.ExperienceEditor.TagHelpers;
 using Sitecore.AspNetCore.SDK.ExperienceEditor.TagHelpers.Model;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/TagHelpers/ChromeDataSerializerFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/TagHelpers/ChromeDataSerializerFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.ExperienceEditor.TagHelpers;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/TagHelpers/EditFrameTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.ExperienceEditor.Tests/TagHelpers/EditFrameTagHelperFixture.cs
@@ -1,6 +1,6 @@
 ﻿using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc.Rendering;

--- a/tests/Sitecore.AspNetCore.SDK.GraphQL.Tests/Extensions/GraphQlConfigurationExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.GraphQL.Tests/Extensions/GraphQlConfigurationExtensionsFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture.Xunit2;
-using FluentAssertions;
+using AwesomeAssertions;
 using GraphQL.Client.Abstractions;
 using GraphQL.Client.Http;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/Sitecore.AspNetCore.SDK.GraphQL.Tests/Request/GraphQLHttpRequestWithHeadersFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.GraphQL.Tests/Request/GraphQLHttpRequestWithHeadersFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using GraphQL.Client.Abstractions;
 using GraphQL.Client.Http;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Integration.Tests/ContextFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Integration.Tests/ContextFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Newtonsoft.Json.Linq;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Integration.Tests/DeviceFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Integration.Tests/DeviceFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Newtonsoft.Json.Linq;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Presentation;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Integration.Tests/EditableChromeFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Integration.Tests/EditableChromeFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Newtonsoft.Json.Linq;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Integration.Tests/FieldsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Integration.Tests/FieldsFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Globalization;
-using FluentAssertions;
+using AwesomeAssertions;
 using Newtonsoft.Json.Linq;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Integration.Tests.MockModels;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Integration.Tests/RequestsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Integration.Tests/RequestsFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net;
 using System.Net.Http.Headers;
-using FluentAssertions;
+using AwesomeAssertions;
 using GraphQL.Client.Abstractions;
 using GraphQL.Client.Http;
 using GraphQL.Client.Serializer.SystemTextJson;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Configuration/HttpLayoutRequestHandlerOptionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Configuration/HttpLayoutRequestHandlerOptionsFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Configuration;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Configuration/SitecoreLayoutClientBuilderFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Configuration/SitecoreLayoutClientBuilderFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Configuration/SitecoreLayoutRequestHandlerBuilderTClientFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Configuration/SitecoreLayoutRequestHandlerBuilderTClientFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Configuration/SitecoreLayoutRequestOptionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Configuration/SitecoreLayoutRequestOptionsFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Configuration;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Configuration/SitecoreLayoutServiceOptionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Configuration/SitecoreLayoutServiceOptionsFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Configuration;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/DefaultLayoutClientFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/DefaultLayoutClientFixture.cs
@@ -1,6 +1,6 @@
 ﻿using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/CouldNotContactSitecoreLayoutServiceClientExceptionFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/CouldNotContactSitecoreLayoutServiceClientExceptionFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Exceptions;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/FieldReaderExceptionFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/FieldReaderExceptionFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Exceptions;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/InvalidRequestSitecoreLayoutServiceClientExceptionFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/InvalidRequestSitecoreLayoutServiceClientExceptionFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Exceptions;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/InvalidResponseSitecoreLayoutServiceClientExceptionFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/InvalidResponseSitecoreLayoutServiceClientExceptionFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Exceptions;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/ItemNotFoundSitecoreLayoutServiceClientExceptionFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/ItemNotFoundSitecoreLayoutServiceClientExceptionFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Exceptions;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/LayoutServiceGraphQlExceptionFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/LayoutServiceGraphQlExceptionFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using GraphQL;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Request.Handlers.GraphQL;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/SitecoreLayoutServiceClientExceptionFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/SitecoreLayoutServiceClientExceptionFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Exceptions;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/SitecoreLayoutServiceMessageConfigurationExceptionFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/SitecoreLayoutServiceMessageConfigurationExceptionFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Exceptions;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/SitecoreLayoutServiceServerExceptionFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Exceptions/SitecoreLayoutServiceServerExceptionFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Exceptions;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Extensions/DictionaryExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Extensions/DictionaryExtensionsFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Extensions/Http/HttpLayoutRequestHandlerBuilderExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Extensions/Http/HttpLayoutRequestHandlerBuilderExtensionsFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Extensions/Http/SitecoreLayoutRequestHttpExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Extensions/Http/SitecoreLayoutRequestHttpExtensionsFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net;
 using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Request;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Extensions/ServiceCollectionExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Extensions/ServiceCollectionExtensionsFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Interfaces;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Extensions/SitecoreLayoutClientBuilderExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Extensions/SitecoreLayoutClientBuilderExtensionsFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Extensions/SitecoreLayoutRequestHandlerBuilderExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Extensions/SitecoreLayoutRequestHandlerBuilderExtensionsFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Request/Handlers/GraphQlLayoutServiceHandlerFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Request/Handlers/GraphQlLayoutServiceHandlerFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json;
 using AutoFixture.Xunit2;
-using FluentAssertions;
+using AwesomeAssertions;
 using GraphQL;
 using GraphQL.Client.Abstractions;
 using Microsoft.Extensions.Logging;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Request/Handlers/HttpLayoutRequestHandlerFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Request/Handlers/HttpLayoutRequestHandlerFixture.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Request/SitecoreLayoutRequestExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Request/SitecoreLayoutRequestExtensionsFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Request;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Request/SitecoreLayoutRequestFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Request/SitecoreLayoutRequestFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Request;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/ComponentFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/ComponentFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/ContextFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/ContextFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/EditableChromeFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/EditableChromeFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/FieldFixtureOfTField.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/FieldFixtureOfTField.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Exceptions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/FieldOfTValueFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/FieldOfTValueFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/Fields/CheckBoxFieldFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/Fields/CheckBoxFieldFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/Fields/ContentListFieldFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/Fields/ContentListFieldFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/Fields/ItemLinkFieldFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/Fields/ItemLinkFieldFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/FieldsReaderFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/FieldsReaderFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Exceptions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/PlaceholderExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/PlaceholderExtensionsFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/PlaceholderFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/PlaceholderFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/Presentation/CachingDataFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/Presentation/CachingDataFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Presentation;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/Presentation/DeviceFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/Presentation/DeviceFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Presentation;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/Presentation/PersonalizationFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/Presentation/PersonalizationFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Presentation;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/Presentation/PlaceholderDataFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/Presentation/PlaceholderDataFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Presentation;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/Presentation/RenderingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/Presentation/RenderingFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Presentation;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/RouteFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/RouteFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/SiteFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/SiteFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/SitecoreDataFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/Model/SitecoreDataFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/SitecoreLayoutResponseContentFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/SitecoreLayoutResponseContentFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/SitecoreLayoutResponseFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Response/SitecoreLayoutResponseFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Serialization/Converter/FieldConverterTests.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Serialization/Converter/FieldConverterTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Serialization/Converter/FieldParserTests.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Serialization/Converter/FieldParserTests.cs
@@ -2,7 +2,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Serialization.Converter;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Serialization.Fields;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Serialization/Converter/PlaceholderFeatureConverterTests.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Serialization/Converter/PlaceholderFeatureConverterTests.cs
@@ -2,7 +2,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Serialization.Converter;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Serialization/Fields/JsonSerializedFieldTests.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Serialization/Fields/JsonSerializedFieldTests.cs
@@ -2,7 +2,7 @@
 using System.Text.Json.Serialization;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Exceptions;

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Serialization/JsonLayoutServiceSerializerFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Serialization/JsonLayoutServiceSerializerFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Serialization;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Controllers/PagesSetupControllerFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Controllers/PagesSetupControllerFixture.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;

--- a/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Extensions/PagesAppConfigurationExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Extensions/PagesAppConfigurationExtensionsFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.Pages.Configuration;
 using Sitecore.AspNetCore.SDK.Pages.Extensions;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Request/Handlers/GraphQL/GraphQLEditingServiceHandlerFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Request/Handlers/GraphQL/GraphQLEditingServiceHandlerFixture.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using GraphQL;
 using GraphQL.Client.Abstractions;
 using Microsoft.Extensions.Logging;

--- a/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Services/DictionaryServiceFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Services/DictionaryServiceFixture.cs
@@ -2,7 +2,7 @@
 using System.Reflection;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using GraphQL;
 using GraphQL.Client.Abstractions;
 using Microsoft.Extensions.Options;

--- a/tests/Sitecore.AspNetCore.SDK.Pages.Tests/TagHelpers/EditingScriptsTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.Pages.Tests/TagHelpers/EditingScriptsTagHelperFixture.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc.Rendering;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ComplexModelBindingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ComplexModelBindingFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/CustomModelContextBindingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/CustomModelContextBindingFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net;
 using System.Text.Json.Nodes;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/CustomResolverBindingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/CustomResolverBindingFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ModelBindingErrorHandlingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ModelBindingErrorHandlingFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ModelBindingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ModelBindingFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ViewFieldsBindingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ViewFieldsBindingFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/ControllerMiddlewareFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/ControllerMiddlewareFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/CustomRenderTypes/LoggingComponentRendererFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/CustomRenderTypes/LoggingComponentRendererFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/CustomRenderTypes/MultipleComponentsAddedFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/CustomRenderTypes/MultipleComponentsAddedFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net;
 using System.Text.Encodings.Web;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/CustomRenderTypes/PartialViewRendererFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/CustomRenderTypes/PartialViewRendererFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/ErrorHandlingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/ErrorHandlingFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net;
 using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/ExperienceEditor/ExperienceEditorCustomRoutingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/ExperienceEditor/ExperienceEditorCustomRoutingFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.TestHost;
 using NSubstitute;
 using Sitecore.AspNetCore.SDK.ExperienceEditor.Extensions;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/ExperienceEditor/ExperienceEditorFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/ExperienceEditor/ExperienceEditorFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net;
 using System.Text;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.TestHost;
 using NSubstitute;
 using Sitecore.AspNetCore.SDK.ExperienceEditor.Extensions;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/ExperienceEditor/ExperienceEditorParsePathByItemIdFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/ExperienceEditor/ExperienceEditorParsePathByItemIdFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Dynamic;
 using System.Text;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.TestHost;
 using NSubstitute;
 using Sitecore.AspNetCore.SDK.ExperienceEditor.Configuration;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/ForwardHeaders/ForwardHeadersToLayoutServiceFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/ForwardHeaders/ForwardHeadersToLayoutServiceFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/GlobalMiddlewareFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/GlobalMiddlewareFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Localization/AdvanceLocalizationFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Localization/AdvanceLocalizationFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Globalization;
 using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Mvc.Razor;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Localization/DefaultLocalizationFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Localization/DefaultLocalizationFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Localization/LocalizationFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Localization/LocalizationFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Globalization;
 using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Localization/LocalizationUsingAttributeMiddlewareFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Localization/LocalizationUsingAttributeMiddlewareFixture.cs
@@ -1,7 +1,7 @@
 ﻿using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Multisite/MultisiteFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Multisite/MultisiteFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net;
 using AutoFixture.Xunit2;
-using FluentAssertions;
+using AwesomeAssertions;
 using GraphQL;
 using GraphQL.Client.Abstractions;
 using Microsoft.AspNetCore.TestHost;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Pages/PagesEditingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Pages/PagesEditingFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using GraphQL;
 using NSubstitute;
 using Sitecore.AspNetCore.SDK.GraphQL.Request;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Pages/PagesSetupRoutingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Pages/PagesSetupRoutingFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.TestData;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/RequestDefaultsConfigurationFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/RequestDefaultsConfigurationFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/RequestExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/RequestExtensionsFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/RequestHeadersValidationFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/RequestHeadersValidationFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/RequestMappingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/RequestMappingFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Primitives;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/SearchOptimization/EdgeSitemapProxyFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/SearchOptimization/EdgeSitemapProxyFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using GraphQL;
 using GraphQL.Client.Abstractions;
 using Microsoft.AspNetCore.TestHost;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/SearchOptimization/SitecoreRewriteFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/SearchOptimization/SitecoreRewriteFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Caching.Memory;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/SearchOptimization/SitemapProxyFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/SearchOptimization/SitemapProxyFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests.Fixtures.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/SitecoreLayoutClientBuilderExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/SitecoreLayoutClientBuilderExtensionsFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Options;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/AllFieldTagHelpersFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/AllFieldTagHelpersFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Globalization;
 using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/DateFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/DateFieldTagHelperFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Globalization;
 using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/FileFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/FileFieldTagHelperFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/ImageFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/ImageFieldTagHelperFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/LinkFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/LinkFieldTagHelperFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/NumberFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/NumberFieldTagHelperFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Globalization;
 using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/PlaceholderTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/PlaceholderTagHelperFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/RichTextFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/RichTextFieldTagHelperFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net;
 using System.Text.Encodings.Web;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/TextFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/TextFieldTagHelperFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net;
 using System.Text.Encodings.Web;
-using FluentAssertions;
+using AwesomeAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Tracking/AttributeBasedTrackingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Tracking/AttributeBasedTrackingFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Tracking/TrackingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Tracking/TrackingFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Tracking/TrackingProxyFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Tracking/TrackingProxyFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Attributes/UseSitecoreRenderingAttributeFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Attributes/UseSitecoreRenderingAttributeFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Attributes;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreComponentFieldAttributeFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreComponentFieldAttributeFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Binding.Attributes;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreComponentFieldsAttributeFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreComponentFieldsAttributeFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Binding.Attributes;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreComponentParameterAttributeFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreComponentParameterAttributeFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Binding.Attributes;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreComponentPropertyAttributeFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreComponentPropertyAttributeFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Binding.Attributes;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreContextAttributeFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreContextAttributeFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Binding.Attributes;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreContextPropertyAttributeFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreContextPropertyAttributeFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Binding.Attributes;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreLayoutResponseAttributeFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreLayoutResponseAttributeFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Binding.Attributes;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreRouteFieldAttributeFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreRouteFieldAttributeFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Binding.Attributes;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreRouteFieldsAttributeFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreRouteFieldsAttributeFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Binding.Attributes;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreRoutePropertyAttributeFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Attributes/SitecoreRoutePropertyAttributeFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Binding.Attributes;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/BindingViewComponentFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/BindingViewComponentFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text;
 using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using NSubstitute;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Extensions/BindingExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Extensions/BindingExtensionsFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Providers/SitecoreLayoutComponentModelBinderProviderFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Providers/SitecoreLayoutComponentModelBinderProviderFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using NSubstitute;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Providers/SitecoreLayoutContextModelBinderProviderFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Providers/SitecoreLayoutContextModelBinderProviderFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using NSubstitute;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Providers/SitecoreLayoutResponseModelBinderProviderFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Providers/SitecoreLayoutResponseModelBinderProviderFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using NSubstitute;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Providers/SitecoreLayoutRouteModelBinderProviderFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Providers/SitecoreLayoutRouteModelBinderProviderFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using NSubstitute;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/SitecoreLayoutModelBinderFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/SitecoreLayoutModelBinderFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/SitecoreViewModelBinderFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/SitecoreViewModelBinderFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text;
 using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutComponentBindingSourceFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutComponentBindingSourceFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutComponentFieldBindingSourceFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutComponentFieldBindingSourceFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutComponentFieldsBindingSourceFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutComponentFieldsBindingSourceFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutComponentParameterBindingSourceFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutComponentParameterBindingSourceFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutComponentPropertyBindingSourceFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutComponentPropertyBindingSourceFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using NSubstitute;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutContextBindingSourceFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutContextBindingSourceFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutContextPropertyBindingSourceFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutContextPropertyBindingSourceFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutResponseBindingSourceFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutResponseBindingSourceFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutRouteBindingSourceFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutRouteBindingSourceFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutRouteFieldBindingSourceFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutRouteFieldBindingSourceFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutRouteFieldsBindingSourceFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutRouteFieldsBindingSourceFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutRoutePropertyBindingSourceFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Binding/Sources/SitecoreLayoutRoutePropertyBindingSourceFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Configuration/RenderingEngineOptionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Configuration/RenderingEngineOptionsFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/ApplicationBuilderExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/ApplicationBuilderExtensionsFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
 using System.Reflection.PortableExecutable;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/EncodingExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/EncodingExtensionsFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Extensions;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/HttpContextExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/HttpContextExtensionsFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using NSubstitute;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/HttpRequestExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/HttpRequestExtensionsFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/MultisiteAppConfigurationExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/MultisiteAppConfigurationExtensionsFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/RazorPageExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/RazorPageExtensionsFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc.Razor;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/RenderingEngineOptionsExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/RenderingEngineOptionsExtensionsFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/ServiceCollectionExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/ServiceCollectionExtensionsFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Binding;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Filters/SitecoreLayoutControllerFilterFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Filters/SitecoreLayoutControllerFilterFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Middleware/MultisiteMiddlewareFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Middleware/MultisiteMiddlewareFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Middleware/RenderingEngineMiddlewareFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Middleware/RenderingEngineMiddlewareFixture.cs
@@ -1,7 +1,7 @@
 ﻿using AutoFixture;
 using AutoFixture.Idioms;
 using AutoFixture.Xunit2;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Middleware/RenderingEnginePipelineFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Middleware/RenderingEnginePipelineFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Options;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/ComponentRendererDescriptorFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/ComponentRendererDescriptorFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using NSubstitute;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Rendering;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/ComponentRendererFactoryFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/ComponentRendererFactoryFixture.cs
@@ -1,6 +1,6 @@
 ﻿using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/EditableChromeRendererFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/EditableChromeRendererFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Html;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/LoggingComponentRendererFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/LoggingComponentRendererFixture.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.Logging;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/PartialViewComponentRendererFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/PartialViewComponentRendererFixture.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/SitecoreRenderingContextFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/SitecoreRenderingContextFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Rendering;
 using Xunit;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/ViewComponentComponentRendererFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/ViewComponentComponentRendererFixture.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Routing/LanguageRouteConstraintFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Routing/LanguageRouteConstraintFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using Microsoft.AspNetCore.Routing;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Routing;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Services/SiteResolverFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Services/SiteResolverFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NSubstitute;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Middleware.Models;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Services;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/SitecoreLayoutRequestMapperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/SitecoreLayoutRequestMapperFixture.cs
@@ -1,6 +1,6 @@
 ﻿using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/ComponentHolderFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/ComponentHolderFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NSubstitute;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Interfaces;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/DateTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/DateTagHelperFixture.cs
@@ -2,7 +2,7 @@
 using System.Globalization;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/FileTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/FileTagHelperFixture.cs
@@ -1,7 +1,7 @@
 ﻿using System.Globalization;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
@@ -2,7 +2,7 @@
 using System.Globalization;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/LinkTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/LinkTagHelperFixture.cs
@@ -1,7 +1,7 @@
 ﻿using System.Globalization;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/NumberTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/NumberTagHelperFixture.cs
@@ -2,7 +2,7 @@
 using System.Globalization;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/RichTextTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/RichTextTagHelperFixture.cs
@@ -2,7 +2,7 @@
 using System.Globalization;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/TextFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/TextFieldTagHelperFixture.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using System.Text.Encodings.Web;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/PlaceholderTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/PlaceholderTagHelperFixture.cs
@@ -2,7 +2,7 @@
 using System.Globalization;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc.Rendering;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/ViewComponents/SitecoreComponentViewComponentFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/ViewComponents/SitecoreComponentViewComponentFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using NSubstitute;

--- a/tests/Sitecore.AspNetCore.SDK.Tracking.Tests/Extensions/TrackingApplicationConfigurationExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.Tracking.Tests/Extensions/TrackingApplicationConfigurationExtensionsFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using NSubstitute;
 using Xunit;
 

--- a/tests/Sitecore.AspNetCore.SDK.Tracking.Tests/Extensions/VisitorIdentificationConfigurationExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.Tracking.Tests/Extensions/VisitorIdentificationConfigurationExtensionsFixture.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;

--- a/tests/Sitecore.AspNetCore.SDK.Tracking.Tests/TagHelpers/SitecoreVisitorIdentificationTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.Tracking.Tests/TagHelpers/SitecoreVisitorIdentificationTagHelperFixture.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using AutoFixture;
 using AutoFixture.Idioms;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc.Rendering;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Apply the label "bug" or "enhancement" as applicable. -->

## Description / Motivation
<!-- Describe your changes in detail -->
Replaced FluentAssertions with AwesomeAssertions and AwesomeAssertions.Analyzers in all test projects. Updated central package management in Directory.Packages.props to include the new assertion library and analyzers.

<!-- Why is this change required? What problem does it solve? -->
FluentAssertions is no longer used; AwesomeAssertions provides improved assertion capabilities and better analyzer support.

<!-- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/Sitecore/ASP.NET-Core-SDK/issues/27


## Testing

- [ ] The Unit & Intergration tests are passing.
- [ ] I have added the necessary tests to cover my changes.

## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [ ] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md).
