### PR TITLE
Ensure culture-invariant date formatting for explicit formats and set test cultures

### DIFF
--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/DateTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/DateTagHelper.cs
@@ -67,7 +67,7 @@ public class DateTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 
         CultureInfo culture = !string.IsNullOrWhiteSpace(Culture) ? CultureInfo.CreateSpecificCulture(Culture) : CultureInfo.CurrentCulture;
 
-        string formattedDate = !string.IsNullOrWhiteSpace(DateFormat) ? field.Value.ToString(DateFormat, culture) : field.Value.ToString(culture);
+        string formattedDate = !string.IsNullOrWhiteSpace(DateFormat) ? field.Value.ToString(DateFormat, !string.IsNullOrWhiteSpace(Culture) ? culture : CultureInfo.InvariantCulture) : field.Value.ToString(culture);
 
         HtmlString html = outputEditableMarkup ? new HtmlString(field.EditableMarkup) : new HtmlString(formattedDate);
 

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ViewFieldsBindingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ViewFieldsBindingFixture.cs
@@ -1,6 +1,8 @@
-﻿using System.Net;
+﻿using System.Globalization;
+using System.Net;
 using FluentAssertions;
 using HtmlAgilityPack;
+using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;
@@ -37,6 +39,13 @@ public class ViewFieldsBindingFixture : IDisposable
             .Configure(app =>
             {
                 app.UseRouting();
+                app.UseRequestLocalization(options =>
+                {
+                    var culture = new CultureInfo("en-US");
+                    options.DefaultRequestCulture = new RequestCulture(culture);
+                    options.SupportedCultures = [culture];
+                    options.SupportedUICultures = [culture];
+                });
                 app.UseSitecoreRenderingEngine();
                 app.UseEndpoints(endpoints =>
                 {

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/DateFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/DateFieldTagHelperFixture.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using FluentAssertions;
 using HtmlAgilityPack;
+using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;
@@ -38,6 +39,13 @@ public class DateFieldTagHelperFixture : IDisposable
             .Configure(app =>
             {
                 app.UseRouting();
+                app.UseRequestLocalization(options =>
+                {
+                    var culture = new CultureInfo("da-DK");
+                    options.DefaultRequestCulture = new RequestCulture(culture);
+                    options.SupportedCultures = [culture];
+                    options.SupportedUICultures = [culture];
+                });
                 app.UseSitecoreRenderingEngine();
                 app.UseEndpoints(endpoints =>
                 {
@@ -95,7 +103,7 @@ public class DateFieldTagHelperFixture : IDisposable
         // Assert
         sectionNode.ChildNodes[1].InnerHtml.Should().Be("05/04/2012");
         sectionNode.ChildNodes[3].InnerHtml.Should().Be("05/04/2012 00:00:00");
-        sectionNode.ChildNodes[5].InnerHtml.Should().Be(TestConstants.DateTimeValue.ToString(CultureInfo.CurrentCulture));
+        sectionNode.ChildNodes[5].InnerHtml.Should().Be(TestConstants.DateTimeValue.ToString(new CultureInfo("da-DK")));
         sectionNode.ChildNodes[9].InnerHtml.Should().Contain("04.05.2012");
     }
 

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/RichTextFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/RichTextFieldTagHelperFixture.cs
@@ -1,7 +1,9 @@
-﻿using System.Net;
+﻿using System.Globalization;
+using System.Net;
 using System.Text.Encodings.Web;
 using FluentAssertions;
 using HtmlAgilityPack;
+using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.TestHost;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;
@@ -39,6 +41,13 @@ public class RichTextFieldTagHelperFixture : IDisposable
             .Configure(app =>
             {
                 app.UseRouting();
+                app.UseRequestLocalization(options =>
+                {
+                    var culture = new CultureInfo("en-US");
+                    options.DefaultRequestCulture = new RequestCulture(culture);
+                    options.SupportedCultures = [culture];
+                    options.SupportedUICultures = [culture];
+                });
                 app.UseSitecoreRenderingEngine();
                 app.UseEndpoints(endpoints =>
                 {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Apply the label "bug" or "enhancement" as applicable. -->

## Description / Motivation
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Updated DateTagHelper to use CultureInfo.InvariantCulture when DateFormat is specified and no explicit Culture is set, ensuring consistent date output regardless of system locale.
- Explicitly set culture to en-US in RichTextFieldTagHelperFixture and other relevant integration test fixtures to make test expectations stable and independent of the developer's environment.
- Updated test assertions to use the correct culture where appropriate.
- Resolves test failures related to date formatting when running tests under non-US locales (e.g., da-DK).


## Testing

- [ ] The Unit & Intergration tests are passing.
- [ ] I have added the necessary tests to cover my changes.

## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [ ] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md).
