### PR TITLE
Option 4 - Fixed - Culture Dependent Date Format Test Failures

### DIFF
--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ViewFieldsBindingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ViewFieldsBindingFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Globalization;
+using System.Net;
 using FluentAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
@@ -75,7 +76,7 @@ public class ViewFieldsBindingFixture : IDisposable
         sectionNode.ChildNodes.First(n => n.Name.Equals("p", StringComparison.OrdinalIgnoreCase)).InnerText
             .Should().BeEmpty();
 
-        sectionNode.ChildNodes.First(n => n.Name.Equals("textarea", StringComparison.OrdinalIgnoreCase)).InnerText.Should().Contain("12/12/2019");
+        sectionNode.ChildNodes.First(n => n.Name.Equals("textarea", StringComparison.OrdinalIgnoreCase)).InnerText.Should().Contain("12/12/2019".Replace("/", CultureInfo.CurrentCulture.DateTimeFormat.DateSeparator));
 
         sectionNode.ChildNodes.First(n => n.Name.Equals("span", StringComparison.OrdinalIgnoreCase)).InnerHtml
             .Should().Be(TestConstants.TestMultilineFieldValue.Replace(Environment.NewLine, "<br>", StringComparison.OrdinalIgnoreCase));

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/AllFieldTagHelpersFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/AllFieldTagHelpersFixture.cs
@@ -82,7 +82,7 @@ public class AllFieldTagHelpersFixture : IDisposable
         sectionNode.ChildNodes.First(n => n.Name.Equals("div", StringComparison.OrdinalIgnoreCase) && n.Id.Equals("div5", StringComparison.OrdinalIgnoreCase)).InnerHtml
             .Should().Be(TestConstants.AllFieldsImageValue);
         sectionNode.ChildNodes.First(n => n.Name.Equals("div", StringComparison.OrdinalIgnoreCase) && n.Id.Equals("div6", StringComparison.OrdinalIgnoreCase)).InnerHtml
-            .Should().Be(TestConstants.DateFieldValue);
+            .Should().Be(TestConstants.DateTimeValue.ToString("MM/dd/yyyy", CultureInfo.CurrentCulture));
         sectionNode.ChildNodes.First(n => n.Name.Equals("div", StringComparison.OrdinalIgnoreCase) && n.Id.Equals("div7", StringComparison.OrdinalIgnoreCase)).InnerHtml
             .Should().Be(TestConstants.MediaLibraryItemImageFieldValue);
         sectionNode.ChildNodes.First(n => n.Name.Equals("div", StringComparison.OrdinalIgnoreCase) && n.Id.Equals("div8", StringComparison.OrdinalIgnoreCase)).InnerHtml

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/DateFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/DateFieldTagHelperFixture.cs
@@ -93,8 +93,8 @@ public class DateFieldTagHelperFixture : IDisposable
         HtmlNode? sectionNode = doc.DocumentNode.ChildNodes.First(n => n.HasClass("component-with-dates"));
 
         // Assert
-        sectionNode.ChildNodes[1].InnerHtml.Should().Be("05/04/2012");
-        sectionNode.ChildNodes[3].InnerHtml.Should().Be("05/04/2012 00:00:00");
+        sectionNode.ChildNodes[1].InnerHtml.Should().Be(TestConstants.DateTimeValue.ToString("MM/dd/yyyy", CultureInfo.CurrentCulture));
+        sectionNode.ChildNodes[3].InnerHtml.Should().Be(TestConstants.DateTimeValue.ToString("MM/dd/yyyy HH:mm:ss", CultureInfo.CurrentCulture));
         sectionNode.ChildNodes[5].InnerHtml.Should().Be(TestConstants.DateTimeValue.ToString(CultureInfo.CurrentCulture));
         sectionNode.ChildNodes[9].InnerHtml.Should().Contain("04.05.2012");
     }

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/RichTextFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/RichTextFieldTagHelperFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Globalization;
+using System.Net;
 using System.Text.Encodings.Web;
 using FluentAssertions;
 using HtmlAgilityPack;
@@ -70,7 +71,7 @@ public class RichTextFieldTagHelperFixture : IDisposable
 
         // Assert
         // check scenario that RichTextTagHelper does not reset values of another helpers.
-        sectionNode.ChildNodes.First(n => n.Name.Equals("textarea", StringComparison.OrdinalIgnoreCase)).InnerText.Should().Contain("12/12/2019");
+        sectionNode.ChildNodes.First(n => n.Name.Equals("textarea", StringComparison.OrdinalIgnoreCase)).InnerText.Should().Contain("12/12/2019".Replace("/", CultureInfo.CurrentCulture.DateTimeFormat.DateSeparator));
     }
 
     [Fact]

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/DateTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/DateTagHelperFixture.cs
@@ -139,7 +139,7 @@ public class DateTagHelperFixture
         sut.Process(tagHelperContext, tagHelperOutput);
 
         // Assert
-        tagHelperOutput.Content.GetContent().Should().Be(_date.ToString(dateFormat, CultureInfo.InvariantCulture));
+        tagHelperOutput.Content.GetContent().Should().Be(_date.ToString(dateFormat, CultureInfo.CurrentCulture));
     }
 
     [Theory]
@@ -274,7 +274,7 @@ public class DateTagHelperFixture
         sut.Process(tagHelperContext, tagHelperOutput);
 
         // Assert
-        tagHelperOutput.Content.GetContent().Should().Be(_date.ToString(dateFormat, CultureInfo.InvariantCulture));
+        tagHelperOutput.Content.GetContent().Should().Be(_date.ToString(dateFormat, CultureInfo.CurrentCulture));
     }
 
     [Theory]


### PR DESCRIPTION
# Fix Culture-Dependent Date Format Test Failures

## Description
This PR fixes test failures that occur when running the test suite on systems with non-US locales (e.g., Danish culture `da-DK`). The issue was caused by hardcoded date format expectations in tests that didn't account for culture-specific date formatting differences.

## Problem
When the system culture was set to Danish (`da-DK`), several date-related tests failed because:
- Danish culture uses hyphens (`-`) as date separators instead of slashes (`/`)
- Tests expected hardcoded US date formats (e.g., `"05/04/2012"`) but got culture-specific formats (e.g., `"05-04-2012"`)
- Unit tests used `CultureInfo.InvariantCulture` for expectations while the actual implementation used `CultureInfo.CurrentCulture`

## Root Cause
The `DateTagHelper` implementation correctly uses `CultureInfo.CurrentCulture` when no specific culture is provided:
```csharp
CultureInfo culture = !string.IsNullOrWhiteSpace(Culture) ? CultureInfo.CreateSpecificCulture(Culture) : CultureInfo.CurrentCulture;
```

However, tests were expecting either:
1. Invariant culture formatting (in unit tests)
2. Hardcoded US date formats (in integration tests)

## Changes Made

### Unit Tests (`DateTagHelperFixture.cs`)
Changed test expectations from `CultureInfo.InvariantCulture` to `CultureInfo.CurrentCulture` to match the actual implementation behavior

### Integration Tests
 Replaced hardcoded date strings with dynamic culture-aware formatting using `TestConstants.DateTimeValue.ToString()` with appropriate format strings and `CultureInfo.CurrentCulture`

`AllFieldTagHelpersFixture.cs`  - Changed from hardcoded `TestConstants.DateFieldValue` to dynamic formatting using `TestConstants.DateTimeValue.ToString("MM/dd/yyyy", CultureInfo.CurrentCulture)`

`ViewFieldsBindingFixture.cs` - Added culture-aware date separator replacement: `"12/12/2019".Replace("/", CultureInfo.CurrentCulture.DateTimeFormat.DateSeparator)`

`RichTextFieldTagHelperFixture.cs`  - Applied the same date separator fix as ViewFieldsBindingFixture.cs
