### PR TITLE
Refactor SrcSet Implementation changes based on PR review - 2025-08-18 - Style, Readability, and Modern C# Improvements

### DIFF
--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -210,7 +210,7 @@ public static partial class SitecoreFieldExtensions
                 parameters[kvp.Key] = kvp.Value.Count > 0 ? kvp.Value[0] : null;
             }
 
-            return original.Substring(0, queryIndex);
+            return original[..queryIndex];
         }
 
         return original;

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -62,7 +62,7 @@ public static partial class SitecoreFieldExtensions
     /// <returns>Merged parameters as dictionary.</returns>
     private static Dictionary<string, object?> MergeParameters(object? imageParams, object? srcSetParams)
     {
-        Dictionary<string, object?> result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, object?> result = new(StringComparer.OrdinalIgnoreCase);
 
         // Add base parameters first
         AddParametersToResult(result, imageParams);
@@ -98,7 +98,7 @@ public static partial class SitecoreFieldExtensions
         }
         else
         {
-            RouteValueDictionary routeValues = new RouteValueDictionary(parameters);
+            RouteValueDictionary routeValues = new(parameters);
             foreach (KeyValuePair<string, object?> kvp in routeValues)
             {
                 if (!skipNullValues || kvp.Value != null)
@@ -151,7 +151,7 @@ public static partial class SitecoreFieldExtensions
         }
 
         // Parse existing query parameters and build merged parameters dictionary
-        Dictionary<string, object?> mergedParams = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, object?> mergedParams = new(StringComparer.OrdinalIgnoreCase);
         Uri? uri = null;
         if (!string.IsNullOrEmpty(urlStr))
         {

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -203,7 +203,7 @@ public static partial class SitecoreFieldExtensions
 
         if (queryIndex >= 0)
         {
-            string query = original.Substring(queryIndex);
+            string query = original[queryIndex..];
             Dictionary<string, Microsoft.Extensions.Primitives.StringValues> parsedQuery = QueryHelpers.ParseQuery(query);
             foreach (KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues> kvp in parsedQuery)
             {

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -81,31 +81,23 @@ public static partial class SitecoreFieldExtensions
     /// <param name="skipNullValues">Whether to skip null values when adding parameters.</param>
     private static void AddParametersToResult(Dictionary<string, object?> result, object? parameters, bool skipNullValues = false)
     {
-        if (parameters == null)
+        switch (parameters)
         {
-            return;
-        }
-
-        if (parameters is Dictionary<string, object?> paramDict)
-        {
-            foreach (KeyValuePair<string, object?> kvp in paramDict)
-            {
-                if (!skipNullValues || kvp.Value != null)
+            case null:
+                break;
+            case Dictionary<string, object?> paramDict:
+                foreach (KeyValuePair<string, object?> kvp in paramDict.Where(kvp => !skipNullValues || kvp.Value != null))
                 {
                     result[kvp.Key] = kvp.Value;
                 }
-            }
-        }
-        else
-        {
-            RouteValueDictionary routeValues = new(parameters);
-            foreach (KeyValuePair<string, object?> kvp in routeValues)
-            {
-                if (!skipNullValues || kvp.Value != null)
+                break;
+            default:
+                RouteValueDictionary routeValues = new(parameters);
+                foreach (KeyValuePair<string, object?> kvp in routeValues.Where(kvp => !skipNullValues || kvp.Value != null))
                 {
                     result[kvp.Key] = kvp.Value;
                 }
-            }
+                break;
         }
     }
 

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -90,6 +90,7 @@ public static partial class SitecoreFieldExtensions
                 {
                     result[kvp.Key] = kvp.Value;
                 }
+
                 break;
             default:
                 RouteValueDictionary routeValues = new(parameters);
@@ -97,6 +98,7 @@ public static partial class SitecoreFieldExtensions
                 {
                     result[kvp.Key] = kvp.Value;
                 }
+
                 break;
         }
     }

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -196,26 +196,24 @@ public static partial class SitecoreFieldExtensions
 
             return url;
         }
-        else
+
+        // For relative URIs, accessing Uri.Query throws InvalidOperationException, so we use string manipulation
+        string original = uri.OriginalString;
+        int queryIndex = original.IndexOf('?');
+
+        if (queryIndex >= 0)
         {
-            // For relative URIs, accessing Uri.Query throws InvalidOperationException, so we use string manipulation
-            string original = uri.OriginalString;
-            int queryIndex = original.IndexOf('?');
-
-            if (queryIndex >= 0)
+            string query = original.Substring(queryIndex);
+            Dictionary<string, Microsoft.Extensions.Primitives.StringValues> parsedQuery = QueryHelpers.ParseQuery(query);
+            foreach (KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues> kvp in parsedQuery)
             {
-                string query = original.Substring(queryIndex);
-                var parsedQuery = QueryHelpers.ParseQuery(query);
-                foreach (var kvp in parsedQuery)
-                {
-                    parameters[kvp.Key] = kvp.Value.Count > 0 ? kvp.Value[0] : null;
-                }
-
-                return original.Substring(0, queryIndex);
+                parameters[kvp.Key] = kvp.Value.Count > 0 ? kvp.Value[0] : null;
             }
 
-            return original;
+            return original.Substring(0, queryIndex);
         }
+
+        return original;
     }
 
     /// <summary>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -23,12 +23,13 @@ public static partial class SitecoreFieldExtensions
         ArgumentNullException.ThrowIfNull(imageField);
         string? urlStr = imageField.Value.Src;
 
-        if (urlStr == null)
+        string? result = null;
+        if (urlStr != null)
         {
-            return null;
+            result = GetSitecoreMediaUri(urlStr, imageParams);
         }
 
-        return GetSitecoreMediaUri(urlStr, imageParams);
+        return result;
     }
 
     /// <summary>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -181,19 +181,19 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 
         // Priority: w > mw > width > maxWidth (matching Content SDK behavior + legacy support)
         string? width = null;
-        if (dictionary.TryGetValue("w", out var wValue))
+        if (dictionary.TryGetValue("w", out object? wValue))
         {
             width = wValue.ToString();
         }
-        else if (dictionary.TryGetValue("mw", out var mwValue))
+        else if (dictionary.TryGetValue("mw", out object? mwValue))
         {
             width = mwValue.ToString();
         }
-        else if (dictionary.TryGetValue("width", out var widthValue))
+        else if (dictionary.TryGetValue("width", out object? widthValue))
         {
             width = widthValue.ToString();
         }
-        else if (dictionary.TryGetValue("maxWidth", out var maxWidthValue))
+        else if (dictionary.TryGetValue("maxWidth", out object? maxWidthValue))
         {
             width = maxWidthValue.ToString();
         }

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -335,7 +335,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
             return string.Empty;
         }
 
-        List<string> srcSetEntries = new();
+        List<string> srcSetEntries = [];
 
         foreach (object srcSetItem in parsedSrcSet)
         {

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -330,11 +330,6 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 
     private string GenerateSrcSetAttribute(ImageField imageField)
     {
-        if (SrcSet == null)
-        {
-            return string.Empty;
-        }
-
         if (SrcSet is not object[] parsedSrcSet || parsedSrcSet.Length == 0)
         {
             return string.Empty;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
@@ -757,7 +757,7 @@ public class ImageTagHelperFixture
         // Assert
         string content = tagHelperOutput.Content.GetContent();
 
-        var srcsetMatch = System.Text.RegularExpressions.Regex.Match(content, "srcset=\"([^\"]*)\"");
+        System.Text.RegularExpressions.Match srcsetMatch = System.Text.RegularExpressions.Regex.Match(content, "srcset=\"([^\"]*)\"");
         srcsetMatch.Success.Should().BeTrue("srcset attribute should be present in the HTML");
 
         string srcsetValue = srcsetMatch.Groups[1].Value;
@@ -766,7 +766,7 @@ public class ImageTagHelperFixture
         srcsetValue.Should().Contain("http://styleguide/-/jssmedia/styleguide/data/media/img/sc_logo.png?iar=0&amp;hash=F313AD90AE547CAB09277E42509E289B&amp;w=400 400w");
         srcsetValue.Should().Contain("http://styleguide/-/jssmedia/styleguide/data/media/img/sc_logo.png?iar=0&amp;hash=F313AD90AE547CAB09277E42509E289B&amp;w=200 200w");
 
-        var entries = srcsetValue.Split(", ");
+        string[] entries = srcsetValue.Split(", ");
         entries.Should().HaveCount(2);
     }
 
@@ -848,11 +848,11 @@ public class ImageTagHelperFixture
         string content = tagHelperOutput.Content.GetContent();
 
         // Extract srcset and sizes using regex for full string comparison
-        var srcsetMatch = System.Text.RegularExpressions.Regex.Match(content, "srcset=\"([^\"]*)\"");
+        System.Text.RegularExpressions.Match srcsetMatch = System.Text.RegularExpressions.Regex.Match(content, "srcset=\"([^\"]*)\"");
         srcsetMatch.Success.Should().BeTrue();
         string srcsetValue = srcsetMatch.Groups[1].Value;
 
-        var sizesMatch = System.Text.RegularExpressions.Regex.Match(content, "sizes=\"([^\"]*)\"");
+        System.Text.RegularExpressions.Match sizesMatch = System.Text.RegularExpressions.Regex.Match(content, "sizes=\"([^\"]*)\"");
         sizesMatch.Success.Should().BeTrue();
         string sizesValue = sizesMatch.Groups[1].Value;
 
@@ -884,7 +884,7 @@ public class ImageTagHelperFixture
         string content = tagHelperOutput.Content.GetContent();
 
         // Extract srcset using regex for full string comparison
-        var srcsetMatch = System.Text.RegularExpressions.Regex.Match(content, "srcset=\"([^\"]*)\"");
+        System.Text.RegularExpressions.Match srcsetMatch = System.Text.RegularExpressions.Regex.Match(content, "srcset=\"([^\"]*)\"");
         srcsetMatch.Success.Should().BeTrue();
         string srcsetValue = srcsetMatch.Groups[1].Value;
 


### PR DESCRIPTION
- Refactored methods to avoid multiple return statements and redundant branches.
- Replaced explicit type declarations with target-typed new expressions (IDE0090).
- Eliminated early returns in favor of switch/case patterns for better readability.
- Updated substring extraction and return statements to use C# range indexers.
- Removed all var usages, replacing them with explicit types.
- Removed unnecessary null checks and used collection initializer syntax for lists.
- Improved overall code clarity, consistency, and compliance with project style guidelines.