### PR TITLE
Refactor URL parsing and `GetMediaLinkForSrcSet `to single-return style - PR Review - 09/15

### DIFF
--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -45,13 +45,14 @@ public static partial class SitecoreFieldExtensions
         ArgumentNullException.ThrowIfNull(imageField);
         string? urlStr = imageField.Value.Src;
 
-        if (urlStr == null)
+        string? result = null;
+        if (urlStr != null)
         {
-            return null;
+            Dictionary<string, object?> mergedParams = MergeParameters(imageParams, srcSetParams);
+            result = GetSitecoreMediaUriWithPreservation(urlStr, mergedParams);
         }
 
-        Dictionary<string, object?> mergedParams = MergeParameters(imageParams, srcSetParams);
-        return GetSitecoreMediaUriWithPreservation(urlStr, mergedParams);
+        return result;
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Apply the label "bug" or "enhancement" as applicable. -->

## Description / Motivation
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Refactor URL parsing and `GetMediaLinkForSrcSet `to single-return style

- Extract `ParseAbsoluteUriParams `and `ParseRelativeUriParams`; make `ParseUrlParams` a single-return wrapper.
- Convert `ParseRelativeUriParams` and `GetSitecoreMediaUriWithPreservation` to single-return style.
- Preserve existing parsing behavior for absolute and relative URIs.
- Improve debuggability and reduce branching/early returns.


## Testing

- [ ] The Unit & Intergration tests are passing.
- [ ] I have added the necessary tests to cover my changes.

## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [ ] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md).
