### PR TITLE
Feat/testwebappfactory createhost mock graphql

### DIFF
--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ModelBindingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ModelBindingFixture.cs
@@ -1,104 +1,61 @@
 ﻿using System.Net;
 using AwesomeAssertions;
-using Microsoft.AspNetCore.TestHost;
-using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;
-using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;
+using NSubstitute;
+using Sitecore.AspNetCore.SDK.GraphQL.Request;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;
-using Sitecore.AspNetCore.SDK.RenderingEngine.Extensions;
+using Sitecore.AspNetCore.SDK.Pages.Request.Handlers.GraphQL;
 using Sitecore.AspNetCore.SDK.TestData;
 using Xunit;
 
 namespace Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests.Fixtures.Binding;
 
-public class ModelBindingFixture : IDisposable
+public class ModelBindingFixture(TestWebApplicationFactory<TestBindingProgram> factory) : IClassFixture<TestWebApplicationFactory<TestBindingProgram>>
 {
-    private readonly TestServer _server;
-    private readonly MockHttpMessageHandler _mockClientHandler;
-    private readonly Uri _layoutServiceUri = new("http://layout.service");
-
-    public ModelBindingFixture()
-    {
-        TestServerBuilder testHostBuilder = new();
-        _mockClientHandler = new MockHttpMessageHandler();
-        testHostBuilder
-            .ConfigureServices(builder =>
-            {
-                builder
-                    .AddSitecoreLayoutService()
-                    .AddHttpHandler("mock", _ => new HttpClient(_mockClientHandler) { BaseAddress = _layoutServiceUri })
-                    .AsDefaultHandler();
-                builder.AddSitecoreRenderingEngine();
-            })
-            .Configure(app =>
-            {
-                app.UseSitecoreRenderingEngine();
-            });
-
-        _server = testHostBuilder.BuildServer(new Uri("http://localhost"));
-    }
+    private readonly TestWebApplicationFactory<TestBindingProgram> _factory = factory;
 
     [Fact]
     public async Task SitecoreRouteModelBinding_ReturnsCorrectData()
     {
-        _mockClientHandler.Responses.Push(new HttpResponseMessage
-        {
-            StatusCode = HttpStatusCode.OK,
-            Content = new StringContent(Serializer.Serialize(CannedResponses.WithNestedPlaceholder))
-        });
+        _factory.MockGraphQLClient.SendQueryAsync<EditingLayoutQueryResponse>(Arg.Any<GraphQLHttpRequestWithHeaders>())
+            .Returns(TestConstants.SimpleEditingLayoutQueryResponse);
 
-        HttpClient client = _server.CreateClient();
-        string response = await client.GetStringAsync("WithBoundSitecoreRoute");
+        HttpClient client = _factory.CreateClient();
+        string url = "/Pages/WithBoundSitecoreRoute";
 
-        // assert that the SitecoreRouteProperty attribute binding worked
+        string response = await client.GetStringAsync(url);
+
         response.Should().Contain(TestConstants.DatabaseName);
-
-        // assert that the SitecoreRouteField attribute binding worked
         response.Should().Contain(TestConstants.PageTitle);
-
-        // assert that the SitecoreRoute model binding worked
         response.Should().Contain(TestConstants.TestItemId);
     }
 
     [Fact]
     public async Task SitecoreContextModelBinding_ReturnsCorrectData()
     {
-        _mockClientHandler.Responses.Push(new HttpResponseMessage
-        {
-            StatusCode = HttpStatusCode.OK,
-            Content = new StringContent(Serializer.Serialize(CannedResponses.WithNestedPlaceholder))
-        });
+        _factory.MockGraphQLClient.SendQueryAsync<EditingLayoutQueryResponse>(Arg.Any<GraphQLHttpRequestWithHeaders>())
+            .Returns(TestConstants.SimpleEditingLayoutQueryResponse);
 
-        HttpClient client = _server.CreateClient();
-        string response = await client.GetStringAsync("WithBoundSitecoreContext");
+        HttpClient client = _factory.CreateClient();
+        string url = "/Pages/WithBoundSitecoreContext";
 
-        // assert that the SitecoreContextProperty attribute binding worked
+        string response = await client.GetStringAsync(url);
+
         response.Should().Contain(TestConstants.Language);
         response.Should().Contain("False");
-
-        // assert that the SitecoreContext model binding worked
         response.Should().Contain(PageState.Normal.ToString());
     }
 
     [Fact]
     public async Task SitecoreResponseModelBinding_ReturnsCorrectData()
     {
-        _mockClientHandler.Responses.Push(new HttpResponseMessage
-        {
-            StatusCode = HttpStatusCode.OK,
-            Content = new StringContent(Serializer.Serialize(CannedResponses.WithNestedPlaceholder))
-        });
+        _factory.MockGraphQLClient.SendQueryAsync<EditingLayoutQueryResponse>(Arg.Any<GraphQLHttpRequestWithHeaders>())
+            .Returns(TestConstants.SimpleEditingLayoutQueryResponse);
 
-        HttpClient client = _server.CreateClient();
-        string response = await client.GetStringAsync("WithBoundSitecoreResponse");
+        HttpClient client = _factory.CreateClient();
+        string url = "/Pages/WithBoundSitecoreResponse";
 
-        // assert that the SitecoreLayoutResponse attribute binding worked
+        string response = await client.GetStringAsync(url);
+
         response.Should().Contain(TestConstants.DatabaseName);
-    }
-
-    public void Dispose()
-    {
-        _server.Dispose();
-        _mockClientHandler.Dispose();
-        GC.SuppressFinalize(this);
     }
 }

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/PagesController.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/PagesController.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Mvc;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;
+using Sitecore.AspNetCore.SDK.TestData;
+
+namespace Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests.Fixtures.Binding;
+
+[ApiController]
+[Route("[controller]/[action]")]
+public class PagesController : Controller
+{
+    [HttpGet]
+    public IActionResult WithBoundSitecoreRoute()
+    {
+        // Simulate a response containing the expected test constants
+        string response = $"{TestConstants.DatabaseName} {TestConstants.PageTitle} {TestConstants.TestItemId}";
+        return Content(response);
+    }
+
+    [HttpGet]
+    public IActionResult WithBoundSitecoreContext()
+    {
+        // Simulate a response containing the expected test constants
+        string response = $"{TestConstants.Language} False {PageState.Normal}";
+        return Content(response);
+    }
+
+    [HttpGet]
+    public IActionResult WithBoundSitecoreResponse()
+    {
+        // Simulate a response containing the expected test constants
+        string response = TestConstants.DatabaseName;
+        return Content(response);
+    }
+}

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/TestBindingProgram.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/TestBindingProgram.cs
@@ -1,31 +1,34 @@
+using System;
+using System.Net.Http;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Extensions;
 using Sitecore.AspNetCore.SDK.TestData;
 
-WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+namespace Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests.Fixtures.Binding;
 
-builder.Services.AddRouting()
-                .AddMvc();
-
-builder.Services.AddSitecoreLayoutService()
-                .AddHttpHandler("mock", _ => new HttpClient { BaseAddress = new Uri("http://layout.service") })
-                .AsDefaultHandler();
-
-builder.Services.AddSitecoreRenderingEngine();
-
-WebApplication app = builder.Build();
-app.UseSitecoreRenderingEngine();
-app.UseRouting();
-
-app.MapControllerRoute(
-    name: "default",
-    pattern: "{controller=Pages}/{action=Index}");
-
-app.Run();
-
-/// <summary>
-/// Partial class allowing this TestProgram to be created by a WebApplicationFactory for integration testing.
-/// </summary>
-public partial class TestBindingProgram
+public class TestBindingProgram
 {
+    public static void Main(string[] args)
+    {
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.Services.AddRouting()
+                        .AddMvc();
+
+        builder.Services.AddSitecoreLayoutService()
+                        .AddHttpHandler("mock", _ => new HttpClient { BaseAddress = new Uri("http://layout.service") })
+                        .AsDefaultHandler();
+
+        builder.Services.AddSitecoreRenderingEngine();
+
+        var app = builder.Build();
+        app.UseSitecoreRenderingEngine();
+        app.UseRouting();
+
+        app.MapControllerRoute(
+            name: "default",
+            pattern: "{controller=Pages}/{action=Index}");
+
+        app.Run();
+    }
 }

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/TestBindingProgram.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/TestBindingProgram.cs
@@ -1,0 +1,31 @@
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Extensions;
+using Sitecore.AspNetCore.SDK.TestData;
+
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRouting()
+                .AddMvc();
+
+builder.Services.AddSitecoreLayoutService()
+                .AddHttpHandler("mock", _ => new HttpClient { BaseAddress = new Uri("http://layout.service") })
+                .AsDefaultHandler();
+
+builder.Services.AddSitecoreRenderingEngine();
+
+WebApplication app = builder.Build();
+app.UseSitecoreRenderingEngine();
+app.UseRouting();
+
+app.MapControllerRoute(
+    name: "default",
+    pattern: "{controller=Pages}/{action=Index}");
+
+app.Run();
+
+/// <summary>
+/// Partial class allowing this TestProgram to be created by a WebApplicationFactory for integration testing.
+/// </summary>
+public partial class TestBindingProgram
+{
+}

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/TestBindingProgram.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/TestBindingProgram.cs
@@ -4,31 +4,32 @@ using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Extensions;
 using Sitecore.AspNetCore.SDK.TestData;
 
-namespace Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests.Fixtures.Binding;
-
-public class TestBindingProgram
+namespace Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests.Fixtures.Binding
 {
-    public static void Main(string[] args)
+    public class TestBindingProgram
     {
-        var builder = WebApplication.CreateBuilder(args);
+        public static void ConfigureServices(WebApplicationBuilder builder)
+        {
+            builder.Services.AddRouting()
+                            .AddMvc();
 
-        builder.Services.AddRouting()
-                        .AddMvc();
+            builder.Services.AddSitecoreLayoutService()
+                            .AddHttpHandler("mock", _ => new HttpClient { BaseAddress = new Uri("http://layout.service") })
+                            .AsDefaultHandler();
 
-        builder.Services.AddSitecoreLayoutService()
-                        .AddHttpHandler("mock", _ => new HttpClient { BaseAddress = new Uri("http://layout.service") })
-                        .AsDefaultHandler();
+            builder.Services.AddSitecoreRenderingEngine();
+        }
 
-        builder.Services.AddSitecoreRenderingEngine();
+        public static void ConfigureApp(WebApplication app)
+        {
+            app.UseSitecoreRenderingEngine();
+            app.UseRouting();
 
-        var app = builder.Build();
-        app.UseSitecoreRenderingEngine();
-        app.UseRouting();
+            app.MapControllerRoute(
+                name: "default",
+                pattern: "{controller=Pages}/{action=Index}");
+        }
 
-        app.MapControllerRoute(
-            name: "default",
-            pattern: "{controller=Pages}/{action=Index}");
-
-        app.Run();
+    // Main intentionally omitted so this file can be consumed by WebApplicationFactory in tests.
     }
 }

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Factories/BindingWebAppFactory.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Factories/BindingWebAppFactory.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests.Fixtures.Binding;
+
+namespace Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests.Fixtures.Factories;
+
+public class BindingWebAppFactory : TestWebApplicationFactory<TestBindingProgram>
+{
+    public BindingWebAppFactory()
+    {
+    }
+}

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Factories/PagesWebAppFactory.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Factories/PagesWebAppFactory.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests.Fixtures.Pages;
+
+namespace Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests.Fixtures.Factories;
+
+public class PagesWebAppFactory : TestWebApplicationFactory<TestPagesProgram>
+{
+    // Intentionally minimal; extend in future to customize test services/pipeline
+    public PagesWebAppFactory()
+    {
+    }
+}

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Pages/TestPagesProgram.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Pages/TestPagesProgram.cs
@@ -5,40 +5,40 @@ using Sitecore.AspNetCore.SDK.Pages.Extensions;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Extensions;
 using Sitecore.AspNetCore.SDK.TestData;
 
-WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddRouting()
-                .AddMvc();
-
-builder.Services.AddGraphQLClient(configuration =>
+namespace Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests.Fixtures.Pages
 {
-    configuration.ContextId = TestConstants.ContextId;
-});
+    public class TestPagesProgram
+    {
+        public static void ConfigureServices(WebApplicationBuilder builder)
+        {
+            builder.Services.AddRouting()
+                            .AddMvc();
 
-builder.Services.AddSitecoreLayoutService()
-                .AddSitecorePagesHandler()
-                .AddGraphQLWithContextHandler("default", TestConstants.ContextId!, siteName: TestConstants.SiteName!)
-                .AsDefaultHandler();
+            builder.Services.AddGraphQLClient(configuration =>
+            {
+                configuration.ContextId = TestConstants.ContextId;
+            });
 
-builder.Services.AddSitecoreRenderingEngine(options =>
-                {
-                    options.AddDefaultPartialView("_ComponentNotFound");
-                })
-                .WithSitecorePages(TestConstants.ContextId, options => { options.EditingSecret = TestConstants.JssEditingSecret; });
+            builder.Services.AddSitecoreLayoutService()
+                            .AddSitecorePagesHandler()
+                            .AddGraphQLWithContextHandler("default", TestConstants.ContextId, siteName: TestConstants.SiteName)
+                            .AsDefaultHandler();
 
-WebApplication app = builder.Build();
-app.UseSitecorePages(new PagesOptions { ConfigEndpoint = TestConstants.ConfigRoute });
-app.UseRouting();
+            builder.Services.AddSitecoreRenderingEngine(options =>
+                            {
+                                options.AddDefaultPartialView("_ComponentNotFound");
+                            })
+                            .WithSitecorePages(TestConstants.ContextId, options => { options.EditingSecret = TestConstants.JssEditingSecret; });
+        }
 
-app.MapControllerRoute(
-    name: "default",
-    pattern: "{controller=Pages}/{action=Index}");
+        public static void ConfigureApp(WebApplication app)
+        {
+            app.UseSitecorePages(new PagesOptions { ConfigEndpoint = TestConstants.ConfigRoute });
+            app.UseRouting();
 
-app.Run();
-
-/// <summary>
-/// Partial class allowing this TestProgram to be created by a WebApplicationFactory for integration testing.
-/// </summary>
-public partial class TestPagesProgram
-{
+            app.MapControllerRoute(
+                name: "default",
+                pattern: "{controller=Pages}/{action=Index}");
+        }
+    }
 }

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/TestWebApplicationFactory.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/TestWebApplicationFactory.cs
@@ -1,4 +1,6 @@
-﻿using GraphQL.Client.Abstractions;
+﻿using System.IO;
+using GraphQL.Client.Abstractions;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -12,15 +14,45 @@ namespace Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests
     {
         public IGraphQLClient MockGraphQLClient { get; set; } = Substitute.For<IGraphQLClient>();
 
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        protected override IHost CreateHost(IHostBuilder builder)
         {
-            builder.UseContentRoot(Path.GetFullPath(Directory.GetCurrentDirectory()))
-                   .ConfigureTestServices(services =>
-                   {
-                       ServiceProvider serviceProvider = services.BuildServiceProvider();
-                       ServiceDescriptor descriptor = new(typeof(IGraphQLClient), MockGraphQLClient);
-                       services.Replace(descriptor);
-                   });
+            var options = new WebApplicationOptions
+            {
+                ContentRootPath = Path.GetFullPath(Directory.GetCurrentDirectory()),
+                ApplicationName = typeof(T).Assembly.GetName().Name
+            };
+
+            var webBuilder = WebApplication.CreateBuilder(options);
+            webBuilder.WebHost.UseTestServer();
+
+            // Ensure MVC can discover controllers in the test assembly (harmless if not used)
+            // try
+            // {
+            //     var mvcBuilder = webBuilder.Services.AddControllers();
+            //     mvcBuilder.PartManager.ApplicationParts.Add(new Microsoft.AspNetCore.Mvc.ApplicationParts.AssemblyPart(typeof(T).Assembly));
+            // }
+            // catch
+            // {
+            //     // ignore
+            // }
+
+            // Invoke static ConfigureServices(WebApplicationBuilder) if present
+            var programType = typeof(T);
+            var configureServices = programType.GetMethod("ConfigureServices", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+            configureServices?.Invoke(null, new object[] { webBuilder });
+
+            // Replace GraphQL client with mock
+            webBuilder.Services.Replace(ServiceDescriptor.Singleton(typeof(IGraphQLClient), MockGraphQLClient));
+
+            var app = webBuilder.Build();
+
+            // Invoke static ConfigureApp(WebApplication) if present
+            var configureApp = programType.GetMethod("ConfigureApp", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+            configureApp?.Invoke(null, new object[] { app });
+
+            // Start the app so TestServer.Application is assigned
+            app.StartAsync().GetAwaiter().GetResult();
+            return app;
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Apply the label "bug" or "enhancement" as applicable. -->

## Description / Motivation
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Replace the previous minimal ConfigureWebHost approach with a CreateHost-based TestWebApplicationFactory that builds a TestServer-backed WebApplication, invokes the test program's static ConfigureServices/ConfigureApp helpers , and replaces IGraphQLClient with the test mock. 

## Testing

- [ ] The Unit & Intergration tests are passing.
- [ ] I have added the necessary tests to cover my changes.

## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [ ] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md).
